### PR TITLE
fix: Use path-based vector_info endpoint and pin black below 26

### DIFF
--- a/pycancensus/vectors.py
+++ b/pycancensus/vectors.py
@@ -126,16 +126,16 @@ def list_census_vectors(
                 print("Reading vectors from cache...")
             return cached_data
 
-    # Query API using the correct endpoint (discovered via diagnostics)
-    params = {"dataset": dataset, "api_key": api_key}
+    # Dataset is a path component, matching the R package:
+    # /api/v1/vector_info/<dataset>.csv (the query-param form returns 404)
+    params = {"api_key": api_key}
 
     try:
         if not quiet:
             print(f"🔍 Querying CensusMapper API for {dataset} vectors...")
 
-        # Use the working CSV endpoint instead of the non-working JSON endpoint
         response = get_session().get(
-            f"{CENSUSMAPPER_API_URL}/vector_info.csv", params=params
+            f"{CENSUSMAPPER_API_URL}/vector_info/{dataset}.csv", params=params
         )
 
         # Parse CSV response

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
 dev = [
     "pytest>=6.0",
     "pytest-cov",
-    "black",
+    "black>=24,<26",
     "flake8",
 ]
 docs = [


### PR DESCRIPTION
Two pre-existing main breakages surfaced by CI on #9 (neither caused by that PR):

- **`list_census_vectors()` 404**: the CensusMapper API no longer serves `/vector_info.csv?dataset=X`; the dataset belongs in the path (`/vector_info/<dataset>.csv`), matching R cancensus. Verified against the live API (7,709 CA21 vectors retrieved). This also un-breaks `search_census_vectors()` and the hierarchy functions.
- **black 26 style drift**: CI installs black unpinned; black 26.5.1's new stable style fails `black --check` on files formatted with 25.x. Pinned `black<26` in dev extras.

🤖 Generated with [Claude Code](https://claude.com/claude-code)