### PR TITLE
fix: Retry 5xx/408/429 responses and honor Retry-After headers

### DIFF
--- a/pycancensus/resilience.py
+++ b/pycancensus/resilience.py
@@ -141,7 +141,7 @@ class ResilientSession:
         pool_connections: int = 10,
         pool_maxsize: int = 20,
         max_retries: int = 3,
-        retry_on_status: tuple = (502, 503, 504),
+        retry_on_status: tuple = (408, 429),
         respect_retry_after: bool = True,
     ):
         """
@@ -156,7 +156,8 @@ class ResilientSession:
         max_retries : int
             Number of retries for failed requests
         retry_on_status : tuple
-            HTTP status codes to retry on
+            HTTP status codes to retry on, in addition to all 5xx responses
+            (which are always treated as transient)
         respect_retry_after : bool
             Whether to respect Retry-After headers
         """
@@ -190,29 +191,28 @@ class ResilientSession:
 
         self._last_request_time = time.time()
 
-    def _handle_rate_limit_response(self, response: requests.Response):
-        """Handle rate limit responses with Retry-After header."""
-        if response.status_code == 429:  # Too Many Requests
-            retry_after = response.headers.get("Retry-After")
+    def _is_retryable_status(self, status_code: int) -> bool:
+        """Check if a status code represents a transient, retryable error."""
+        return 500 <= status_code < 600 or status_code in self.retry_on_status
 
-            if retry_after and self.respect_retry_after:
-                try:
-                    retry_seconds = int(retry_after)
-                    raise RateLimitError(
-                        f"Rate limit exceeded",
-                        status_code=429,
-                        retry_after=retry_seconds,
-                        suggestion=f"Wait {retry_seconds} seconds before retrying",
-                    )
-                except ValueError:
-                    # Retry-After might be a date instead of seconds
-                    pass
+    def _retry_after_seconds(self, response: requests.Response) -> Optional[int]:
+        """Parse a numeric Retry-After header, if present and respected."""
+        if not self.respect_retry_after:
+            return None
+        retry_after = response.headers.get("Retry-After")
+        if retry_after is None:
+            return None
+        try:
+            seconds = int(float(retry_after))
+        except ValueError:
+            # Retry-After might be an HTTP date instead of seconds
+            return None
+        return seconds if seconds > 0 else None
 
-            raise RateLimitError(
-                "Rate limit exceeded",
-                status_code=429,
-                suggestion="Reduce request frequency or contact API provider",
-            )
+    def _backoff_delay(self, attempt: int) -> float:
+        """Exponential backoff (1, 2, 4, ... seconds) with jitter, capped at 60s."""
+        delay = min(2.0**attempt, 60.0)
+        return delay * (0.5 + random.random() * 0.5)
 
     def _create_appropriate_exception(
         self, response: requests.Response
@@ -223,7 +223,12 @@ class ResilientSession:
         elif response.status_code == 404:
             return DataNotFoundError("API endpoint or data not found")
         elif response.status_code == 429:
-            return RateLimitError("Rate limit exceeded")
+            return RateLimitError(
+                "Rate limit exceeded",
+                status_code=429,
+                retry_after=self._retry_after_seconds(response),
+                suggestion="Reduce request frequency or contact API provider",
+            )
         elif response.status_code >= 500:
             return CensusAPIError(
                 f"Server error: {response.status_code}",
@@ -235,10 +240,14 @@ class ResilientSession:
                 f"HTTP error: {response.status_code}", status_code=response.status_code
             )
 
-    @retry_with_backoff(max_retries=3, base_delay=1.0)
     def request(self, method: str, url: str, **kwargs) -> requests.Response:
         """
         Make a resilient HTTP request with automatic retries.
+
+        Transient failures (network errors, 5xx responses, and the status
+        codes in ``retry_on_status`` — by default 408 and 429) are retried
+        with exponential backoff. A numeric Retry-After header extends the
+        wait, capped at 60 seconds.
 
         Parameters
         ----------
@@ -259,34 +268,47 @@ class ResilientSession:
         CensusAPIError
             For various API error conditions
         """
-        # Enforce rate limiting
-        self._enforce_rate_limit()
-
         # Set default timeout if not provided
         if "timeout" not in kwargs:
             kwargs["timeout"] = 30
 
-        try:
-            response = self.session.request(method, url, **kwargs)
+        for attempt in range(self.max_retries + 1):
+            # Enforce rate limiting
+            self._enforce_rate_limit()
 
-            # Handle rate limiting
-            if response.status_code == 429:
-                self._handle_rate_limit_response(response)
+            try:
+                response = self.session.request(method, url, **kwargs)
+            except requests.exceptions.RequestException as e:
+                if attempt < self.max_retries:
+                    delay = self._backoff_delay(attempt)
+                    logger.warning(
+                        f"Network error: {e}. Retrying in {delay:.1f}s "
+                        f"(attempt {attempt + 2}/{self.max_retries + 1})..."
+                    )
+                    time.sleep(delay)
+                    continue
+                logger.error(f"All {self.max_retries + 1} attempts failed: {e}")
+                raise
 
-            # Handle other error status codes
-            if not response.ok:
-                if response.status_code in self.retry_on_status:
-                    # These status codes will be retried by the decorator
-                    response.raise_for_status()
-                else:
-                    # These are permanent errors, don't retry
-                    raise self._create_appropriate_exception(response)
+            if response.ok:
+                return response
 
-            return response
+            if self._is_retryable_status(response.status_code) and (
+                attempt < self.max_retries
+            ):
+                delay = self._backoff_delay(attempt)
+                retry_after = self._retry_after_seconds(response)
+                if retry_after is not None:
+                    delay = max(delay, min(retry_after, 60))
+                logger.warning(
+                    f"Transient error (HTTP {response.status_code}), retrying "
+                    f"in {delay:.1f}s (attempt {attempt + 2}/{self.max_retries + 1})..."
+                )
+                time.sleep(delay)
+                continue
 
-        except requests.exceptions.RequestException as e:
-            logger.error(f"Network error: {e}")
-            raise
+            # Permanent error, or transient error with retries exhausted
+            raise self._create_appropriate_exception(response)
 
     def get(self, url: str, **kwargs) -> requests.Response:
         """Make a GET request."""

--- a/tests/test_resilience.py
+++ b/tests/test_resilience.py
@@ -1,0 +1,157 @@
+"""Tests for retry and error handling in pycancensus.resilience."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from pycancensus.resilience import (
+    AuthenticationError,
+    CensusAPIError,
+    DataNotFoundError,
+    RateLimitError,
+    ResilientSession,
+)
+
+
+def make_response(status_code, headers=None):
+    """Build a mock requests.Response with the given status."""
+    response = MagicMock(spec=requests.Response)
+    response.status_code = status_code
+    response.ok = status_code < 400
+    response.headers = headers or {}
+    return response
+
+
+def make_session(**kwargs):
+    """Build a ResilientSession with rate-limit pacing disabled."""
+    session = ResilientSession(**kwargs)
+    session._min_request_interval = 0
+    return session
+
+
+class TestRetryableStatuses:
+    """Transient statuses (5xx, 408, 429) are retried; permanent ones are not."""
+
+    @pytest.mark.parametrize("status", [408, 429, 500, 502, 503, 504])
+    @patch("pycancensus.resilience.time.sleep")
+    def test_transient_status_retried_until_success(self, mock_sleep, status):
+        session = make_session(max_retries=3)
+        responses = [make_response(status), make_response(200)]
+        session.session.request = MagicMock(side_effect=responses)
+
+        result = session.request("GET", "https://example.com")
+
+        assert result.status_code == 200
+        assert session.session.request.call_count == 2
+
+    @pytest.mark.parametrize("status", [429, 503])
+    @patch("pycancensus.resilience.time.sleep")
+    def test_transient_status_raises_after_exhausting_retries(self, mock_sleep, status):
+        session = make_session(max_retries=2)
+        session.session.request = MagicMock(return_value=make_response(status))
+
+        with pytest.raises(CensusAPIError):
+            session.request("GET", "https://example.com")
+
+        assert session.session.request.call_count == 3  # initial + 2 retries
+
+    @pytest.mark.parametrize(
+        "status,exception",
+        [(401, AuthenticationError), (404, DataNotFoundError)],
+    )
+    @patch("pycancensus.resilience.time.sleep")
+    def test_permanent_status_not_retried(self, mock_sleep, status, exception):
+        session = make_session(max_retries=3)
+        session.session.request = MagicMock(return_value=make_response(status))
+
+        with pytest.raises(exception):
+            session.request("GET", "https://example.com")
+
+        assert session.session.request.call_count == 1
+        mock_sleep.assert_not_called()
+
+    @patch("pycancensus.resilience.time.sleep")
+    def test_network_error_retried(self, mock_sleep):
+        session = make_session(max_retries=3)
+        session.session.request = MagicMock(
+            side_effect=[
+                requests.exceptions.ConnectionError("boom"),
+                make_response(200),
+            ]
+        )
+
+        result = session.request("GET", "https://example.com")
+
+        assert result.status_code == 200
+        assert session.session.request.call_count == 2
+
+    @patch("pycancensus.resilience.time.sleep")
+    def test_network_error_raises_after_exhausting_retries(self, mock_sleep):
+        session = make_session(max_retries=2)
+        session.session.request = MagicMock(
+            side_effect=requests.exceptions.ConnectionError("boom")
+        )
+
+        with pytest.raises(requests.exceptions.ConnectionError):
+            session.request("GET", "https://example.com")
+
+        assert session.session.request.call_count == 3
+
+
+class TestRetryAfter:
+    """Numeric Retry-After headers extend the backoff wait, capped at 60s."""
+
+    @patch("pycancensus.resilience.time.sleep")
+    def test_retry_after_extends_wait(self, mock_sleep):
+        session = make_session(max_retries=1)
+        responses = [
+            make_response(429, headers={"Retry-After": "42"}),
+            make_response(200),
+        ]
+        session.session.request = MagicMock(side_effect=responses)
+
+        session.request("GET", "https://example.com")
+
+        (waited,) = mock_sleep.call_args[0]
+        assert waited >= 42
+
+    @patch("pycancensus.resilience.time.sleep")
+    def test_retry_after_capped_at_60s(self, mock_sleep):
+        session = make_session(max_retries=1)
+        responses = [
+            make_response(429, headers={"Retry-After": "600"}),
+            make_response(200),
+        ]
+        session.session.request = MagicMock(side_effect=responses)
+
+        session.request("GET", "https://example.com")
+
+        (waited,) = mock_sleep.call_args[0]
+        assert waited <= 60
+
+    @patch("pycancensus.resilience.time.sleep")
+    def test_http_date_retry_after_ignored(self, mock_sleep):
+        session = make_session(max_retries=1)
+        responses = [
+            make_response(
+                429, headers={"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"}
+            ),
+            make_response(200),
+        ]
+        session.session.request = MagicMock(side_effect=responses)
+
+        result = session.request("GET", "https://example.com")
+
+        assert result.status_code == 200
+
+    def test_rate_limit_error_carries_retry_after(self):
+        session = make_session(max_retries=0)
+        session.session.request = MagicMock(
+            return_value=make_response(429, headers={"Retry-After": "17"})
+        )
+
+        with pytest.raises(RateLimitError) as excinfo:
+            session.request("GET", "https://example.com")
+
+        assert excinfo.value.retry_after == 17


### PR DESCRIPTION
First item from UPDATE_PLAN.md (A1), porting R cancensus 0.6.1's retry semantics.

**Before:** only 502/503/504 were retried. A 429 raised `RateLimitError` immediately — the `@retry_with_backoff` decorator only catches `RequestException`, so rate-limited requests were never retried. 408/500/501 were treated as permanent. `Retry-After` was parsed but only used in the error message; the session never waited.

**After:** `ResilientSession.request()` runs its own retry loop mirroring R's `retry_api_call()` (helpers.R): all 5xx plus 408/429 retry with exponential backoff (1→2→4s, jittered); a numeric `Retry-After` extends the wait, capped at 60s; HTTP-date `Retry-After` values are ignored like R's `as.numeric` NA path. Permanent errors (401/404/etc.) still fail fast. `RateLimitError` now carries `retry_after` when retries are exhausted.

16 new unit tests in `tests/test_resilience.py` cover retry-until-success, retry exhaustion, fail-fast on permanent statuses, network-error retries, and Retry-After extension/capping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)