### PR TITLE
perf: Add in-memory session cache for vector and region lists

### DIFF
--- a/pycancensus/cache.py
+++ b/pycancensus/cache.py
@@ -12,6 +12,39 @@ import geopandas as gpd
 
 from .settings import get_cache_path
 
+# In-memory session cache for metadata (vector and region lists). Sits in
+# front of the file cache so repeated calls within a session don't pay the
+# disk read + unpickle cost on every access.
+_session_cache: dict = {}
+
+
+def session_cache_get(cache_key: str) -> Optional[Any]:
+    """Get a value from the in-memory session cache."""
+    value = _session_cache.get(cache_key)
+    if isinstance(value, pd.DataFrame):
+        # Hand out copies so callers can't mutate the cached object
+        return value.copy()
+    return value
+
+
+def session_cache_set(cache_key: str, value: Any) -> Any:
+    """Store a value in the in-memory session cache."""
+    if isinstance(value, pd.DataFrame):
+        # Store a private copy so later caller mutations can't corrupt it
+        _session_cache[cache_key] = value.copy()
+    else:
+        _session_cache[cache_key] = value
+    return value
+
+
+def _session_cache_remove(cache_keys: Optional[List[str]] = None) -> None:
+    """Drop specific keys (or everything, if None) from the session cache."""
+    if cache_keys is None:
+        _session_cache.clear()
+    else:
+        for cache_key in cache_keys:
+            _session_cache.pop(cache_key, None)
+
 
 def get_cached_data(cache_key: str) -> Optional[Any]:
     """
@@ -134,6 +167,12 @@ def remove_from_cache(
     >>> # Remove all cache (use with caution!)
     >>> pc.remove_from_cache(all_cache=True)
     """
+    # Keep the in-memory session cache consistent with the file cache
+    if all_cache:
+        _session_cache_remove()
+    elif cache_keys:
+        _session_cache_remove(cache_keys)
+
     cache_path = Path(get_cache_path())
 
     if not cache_path.exists():

--- a/pycancensus/regions.py
+++ b/pycancensus/regions.py
@@ -11,7 +11,7 @@ import requests
 from .settings import get_api_key, CENSUSMAPPER_DATA_URL
 from .resilience import get_session
 from .utils import validate_dataset
-from .cache import get_cached_data, cache_data
+from .cache import get_cached_data, cache_data, session_cache_get, session_cache_set
 
 
 def list_census_regions(
@@ -62,13 +62,17 @@ def list_census_regions(
                 "environment variable."
             )
 
-    # Check cache first
+    # Check caches first: in-memory session cache, then file cache
+    cache_key = f"regions_{dataset}"
     if use_cache:
-        cache_key = f"regions_{dataset}"
+        cached_data = session_cache_get(cache_key)
+        if cached_data is not None:
+            return cached_data
         cached_data = get_cached_data(cache_key)
         if cached_data is not None:
             if not quiet:
                 print("Reading regions from cache...")
+            session_cache_set(cache_key, cached_data)
             return cached_data
 
     # Query API using the correct endpoint (same as R cancensus)
@@ -97,6 +101,7 @@ def list_census_regions(
         df = df.rename(columns=column_mapping)
 
         # Cache the result
+        session_cache_set(cache_key, df)
         if use_cache:
             cache_data(cache_key, df)
 

--- a/pycancensus/vectors.py
+++ b/pycancensus/vectors.py
@@ -12,7 +12,7 @@ import requests
 from .settings import get_api_key, CENSUSMAPPER_API_URL
 from .resilience import get_session
 from .utils import validate_dataset
-from .cache import get_cached_data, cache_data
+from .cache import get_cached_data, cache_data, session_cache_get, session_cache_set
 
 
 def label_vectors(x):
@@ -117,13 +117,17 @@ def list_census_vectors(
                 "environment variable."
             )
 
-    # Check cache first
+    # Check caches first: in-memory session cache, then file cache
+    cache_key = f"vectors_{dataset}"
     if use_cache:
-        cache_key = f"vectors_{dataset}"
+        cached_data = session_cache_get(cache_key)
+        if cached_data is not None:
+            return cached_data
         cached_data = get_cached_data(cache_key)
         if cached_data is not None:
             if not quiet:
                 print("Reading vectors from cache...")
+            session_cache_set(cache_key, cached_data)
             return cached_data
 
     # Dataset is a path component, matching the R package:
@@ -168,6 +172,7 @@ def list_census_vectors(
             df["parent_vector"] = df["parent_vector"].replace(["", "NA"], None)
 
         # Cache the result
+        session_cache_set(cache_key, df)
         if use_cache:
             cache_data(cache_key, df)
 

--- a/tests/test_session_cache.py
+++ b/tests/test_session_cache.py
@@ -1,0 +1,131 @@
+"""Tests for the in-memory session cache layer."""
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+import pycancensus.cache as cache_mod
+from pycancensus.cache import (
+    remove_from_cache,
+    session_cache_get,
+    session_cache_set,
+)
+from pycancensus.vectors import list_census_vectors
+
+
+@pytest.fixture(autouse=True)
+def clean_session_cache():
+    cache_mod._session_cache.clear()
+    yield
+    cache_mod._session_cache.clear()
+
+
+def make_vectors_df():
+    return pd.DataFrame(
+        {
+            "vector": ["v_CA21_1", "v_CA21_2"],
+            "label": ["Population", "Dwellings"],
+            "type": ["Total", "Total"],
+            "parent_vector": [None, None],
+        }
+    )
+
+
+class TestSessionCachePrimitives:
+    def test_get_returns_none_on_miss(self):
+        assert session_cache_get("nope") is None
+
+    def test_set_then_get_roundtrip(self):
+        df = make_vectors_df()
+        session_cache_set("key", df)
+        result = session_cache_get("key")
+        pd.testing.assert_frame_equal(result, df)
+
+    def test_cached_value_immune_to_caller_mutation(self):
+        df = make_vectors_df()
+        session_cache_set("key", df)
+        df.loc[0, "label"] = "CORRUPTED"
+
+        assert session_cache_get("key")["label"].iloc[0] == "Population"
+
+    def test_returned_value_immune_to_later_mutation(self):
+        session_cache_set("key", make_vectors_df())
+        first = session_cache_get("key")
+        first.loc[0, "label"] = "CORRUPTED"
+
+        assert session_cache_get("key")["label"].iloc[0] == "Population"
+
+    def test_remove_from_cache_invalidates_keys(self):
+        session_cache_set("vectors_CA21", make_vectors_df())
+        with patch.object(cache_mod, "get_cache_path", return_value="/nonexistent"):
+            remove_from_cache(["vectors_CA21"])
+        assert session_cache_get("vectors_CA21") is None
+
+    def test_remove_all_clears_session_cache(self):
+        session_cache_set("a", 1)
+        session_cache_set("b", 2)
+        with patch.object(cache_mod, "get_cache_path", return_value="/nonexistent"):
+            remove_from_cache(all_cache=True)
+        assert session_cache_get("a") is None
+        assert session_cache_get("b") is None
+
+
+class TestListVectorsSessionCache:
+    @patch("pycancensus.vectors.get_session")
+    @patch("pycancensus.vectors.get_cached_data", return_value=None)
+    @patch("pycancensus.vectors.cache_data")
+    @patch("pycancensus.vectors.get_api_key", return_value="test_key")
+    def test_second_call_skips_api_and_file_cache(
+        self, mock_key, mock_cache_write, mock_file_cache, mock_get_session
+    ):
+        response = MagicMock()
+        response.text = (
+            "vector,type,label,units,add,parent,details\n"
+            "v_CA21_1,Total,Population,Number,1,,Population\n"
+        )
+        session = MagicMock()
+        session.get.return_value = response
+        mock_get_session.return_value = session
+
+        first = list_census_vectors("CA21", quiet=True)
+        second = list_census_vectors("CA21", quiet=True)
+
+        assert session.get.call_count == 1  # API hit only once
+        assert mock_file_cache.call_count == 1  # file cache read only once
+        pd.testing.assert_frame_equal(first, second)
+
+    @patch("pycancensus.vectors.get_session")
+    @patch("pycancensus.vectors.get_cached_data")
+    @patch("pycancensus.vectors.get_api_key", return_value="test_key")
+    def test_file_cache_hit_populates_session_cache(
+        self, mock_key, mock_file_cache, mock_get_session
+    ):
+        mock_file_cache.return_value = make_vectors_df()
+
+        list_census_vectors("CA21", quiet=True)
+        list_census_vectors("CA21", quiet=True)
+
+        assert mock_file_cache.call_count == 1
+        mock_get_session.assert_not_called()
+
+    @patch("pycancensus.vectors.get_session")
+    @patch("pycancensus.vectors.get_cached_data", return_value=None)
+    @patch("pycancensus.vectors.cache_data")
+    @patch("pycancensus.vectors.get_api_key", return_value="test_key")
+    def test_use_cache_false_bypasses_session_cache(
+        self, mock_key, mock_cache_write, mock_file_cache, mock_get_session
+    ):
+        response = MagicMock()
+        response.text = (
+            "vector,type,label,units,add,parent,details\n"
+            "v_CA21_1,Total,Population,Number,1,,Population\n"
+        )
+        session = MagicMock()
+        session.get.return_value = response
+        mock_get_session.return_value = session
+
+        list_census_vectors("CA21", quiet=True, use_cache=False)
+        list_census_vectors("CA21", quiet=True, use_cache=False)
+
+        assert session.get.call_count == 2


### PR DESCRIPTION
UPDATE_PLAN.md item B1, porting R cancensus 0.6.1's session cache (helpers.R).

`list_census_vectors()` and `list_census_regions()` re-read and unpickled the file cache on every call. A module-level dict now fronts the file cache; repeated metadata access within a session skips disk entirely. Measured ~9x faster cache hits locally (0.18ms vs 1.63ms for the 7,709-row CA21 vector list) — the win compounds in hot paths like hierarchy traversal and search that call these repeatedly.

Safety details:
- DataFrames are defensively copied on store **and** retrieve, so caller mutations can't corrupt the cache (R gets this for free from copy-on-write).
- `remove_from_cache()` / `clear_cache()` invalidate session entries alongside files.
- `use_cache=False` bypasses the session cache for both read and write of the file cache, but still refreshes the session entry from the live response.

9 new unit tests cover roundtrip, mutation immunity both directions, invalidation, API-call elision, and the use_cache=False path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)