### PR TITLE
fix: Consolidate vector search and port R's exact/semantic/keyword modes

### DIFF
--- a/comprehensive_example_validator.py
+++ b/comprehensive_example_validator.py
@@ -339,7 +339,7 @@ def main():
         r_code="""
         result <- find_census_vectors('Oji-cree', dataset = 'CA16', query_type = 'exact')
         """,
-        python_func=lambda: pc.find_census_vectors('CA16', 'Oji-cree', search_type='exact')
+        python_func=lambda: pc.find_census_vectors('Oji-cree', 'CA16', query_type='exact')
     )
 
     validator.validate_example(
@@ -347,7 +347,7 @@ def main():
         r_code="""
         result <- find_census_vectors('commuting duration', dataset = 'CA11', query_type = 'keyword')
         """,
-        python_func=lambda: pc.find_census_vectors('CA11', 'commuting duration', search_type='keyword')
+        python_func=lambda: pc.find_census_vectors('commuting duration', 'CA11', query_type='keyword')
     )
 
     validator.validate_example(
@@ -355,7 +355,7 @@ def main():
         r_code="""
         result <- find_census_vectors('after tax income', dataset = 'CA16', query_type = 'keyword')
         """,
-        python_func=lambda: pc.find_census_vectors('CA16', 'after tax income', search_type='keyword')
+        python_func=lambda: pc.find_census_vectors('after tax income', 'CA16', query_type='keyword')
     )
 
     # ========================================================================

--- a/docs/examples/plot_basic_census_data.py
+++ b/docs/examples/plot_basic_census_data.py
@@ -154,7 +154,7 @@ except Exception as e:
 print("\nVector Hierarchy Navigation:")
 try:
     # Find vectors using enhanced search
-    income_vectors = pc.find_census_vectors("CA21", "income")
+    income_vectors = pc.find_census_vectors("income", "CA21", query_type="keyword")
     print(f"Found {len(income_vectors)} income-related vectors")
     
     # Navigate vector hierarchies using household income as example

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -18,7 +18,7 @@ This tutorial demonstrates the enhanced pycancensus functionality with clear hie
 ## Key Features Demonstrated:
 - **list_census_vectors()** - Browse all available data variables
 - **Vector Hierarchies** - Navigate parent-child relationships
-- **find_census_vectors()** - Smart search functionality
+- **find_census_vectors()** - Exact, semantic, and keyword search
 - **Real Data Retrieval** - Get actual census data
 
 ```{note}
@@ -131,15 +131,16 @@ except Exception as e:
 
 ## 3. Enhanced Vector Search
 
-The `find_census_vectors()` function provides smart search with relevance scoring:
+The `find_census_vectors()` function supports exact, semantic, and keyword search
+(matching the R cancensus package):
 
 ```{code-cell} python
 try:
     # Search for income-related vectors
-    income_vectors = find_census_vectors('CA21', 'income')
+    income_vectors = find_census_vectors('income', 'CA21', query_type='keyword')
     print(f"Found {len(income_vectors)} income-related vectors")
-    print(f"\nTop income vectors (sorted by relevance):")
-    display(income_vectors[['vector', 'label', 'relevance_score']].head(3))
+    print(f"\nTop income vectors:")
+    display(income_vectors[['vector', 'label']].head(3))
     
 except Exception as e:
     print(f"Error searching vectors: {e}")
@@ -185,7 +186,7 @@ except Exception as e:
 1. **list_census_vectors()** - Browse 7,709+ available variables with explicit parent-child relationships
 2. **Hierarchy Navigation** - Navigate through income hierarchies from main categories to detailed brackets
 3. **parent_census_vectors()** & **child_census_vectors()** - Navigate up and down the hierarchy
-4. **find_census_vectors()** - Smart search with relevance scoring 
+4. **find_census_vectors()** - Exact, semantic, and keyword search modes 
 5. **Real Data** - Actual census data retrieved and analyzed
 
 **Key Improvement**: Unlike previous versions, these hierarchy functions now work with **clear, well-defined parent-child relationships** in the census data structure.

--- a/pycancensus/__init__.py
+++ b/pycancensus/__init__.py
@@ -13,7 +13,12 @@ __email__ = "shkolnikd@gmail.com"
 
 from .core import get_census
 from .regions import list_census_regions, search_census_regions
-from .vectors import list_census_vectors, search_census_vectors, label_vectors
+from .vectors import (
+    list_census_vectors,
+    search_census_vectors,
+    find_census_vectors,
+    label_vectors,
+)
 from .datasets import list_census_datasets, dataset_attribution
 from .settings import (
     set_api_key,
@@ -25,7 +30,7 @@ from .settings import (
 )
 from .geometry import get_census_geometry
 from .cache import list_cache, remove_from_cache, clear_cache
-from .hierarchy import parent_census_vectors, child_census_vectors, find_census_vectors
+from .hierarchy import parent_census_vectors, child_census_vectors
 from .intersect_geometry import get_intersecting_geometries
 
 __all__ = [

--- a/pycancensus/hierarchy.py
+++ b/pycancensus/hierarchy.py
@@ -1,6 +1,5 @@
 """Vector hierarchy navigation functions for pycancensus."""
 
-import re
 import warnings
 from typing import Dict, List, Optional, Union
 
@@ -206,91 +205,3 @@ def child_census_vectors(
         return pd.DataFrame(columns=all_vectors.columns)
 
     return all_vectors.set_index("vector").loc[seen].reset_index()[all_vectors.columns]
-
-
-def find_census_vectors(
-    dataset: str,
-    query: str,
-    search_type: str = "keyword",
-    use_cache: bool = True,
-    api_key: Optional[str] = None,
-) -> pd.DataFrame:
-    """
-    Enhanced vector search with multiple search types.
-
-    Parameters
-    ----------
-    dataset : str
-        Dataset to search in
-    query : str
-        Search query
-    search_type : str, default "keyword"
-        Type of search: "keyword", "exact", "regex"
-    use_cache : bool, default True
-        Whether to use cached data if available
-    api_key : str, optional
-        API key for CensusMapper API
-
-    Returns
-    -------
-    pd.DataFrame
-        Matching vectors with relevance information
-    """
-    dataset = validate_dataset(dataset)
-
-    # Get all vectors for the dataset
-    from .vectors import list_census_vectors
-
-    try:
-        all_vectors = list_census_vectors(dataset, use_cache=use_cache, api_key=api_key)
-    except Exception as e:
-        warnings.warn(f"Could not retrieve vector list for search: {e}")
-        return pd.DataFrame()
-
-    if all_vectors.empty:
-        return pd.DataFrame()
-
-    # Perform search based on type
-    query_lower = query.lower()
-
-    if search_type == "exact":
-        # Exact match in label or vector ID
-        mask = (all_vectors["vector"].str.lower() == query_lower) | (
-            all_vectors["label"].str.lower() == query_lower
-        )
-    elif search_type == "regex":
-        # Regex search
-        try:
-            pattern = re.compile(query, re.IGNORECASE)
-            mask = all_vectors["label"].str.contains(pattern, na=False) | all_vectors[
-                "vector"
-            ].str.contains(pattern, na=False)
-            if "details" in all_vectors.columns:
-                mask |= all_vectors["details"].str.contains(pattern, na=False)
-        except re.error:
-            warnings.warn(f"Invalid regex pattern: {query}")
-            return pd.DataFrame()
-    else:  # keyword search (default)
-        # Keyword search in label and details
-        mask = all_vectors["label"].str.contains(query, case=False, na=False)
-        if "details" in all_vectors.columns:
-            mask |= all_vectors["details"].str.contains(query, case=False, na=False)
-
-    result = all_vectors[mask].copy()
-
-    if not result.empty:
-        # Add relevance scoring
-        result["relevance_score"] = 0.0
-
-        # Higher score for matches in vector ID
-        vector_match = result["vector"].str.contains(query, case=False, na=False)
-        result.loc[vector_match, "relevance_score"] += 10
-
-        # Higher score for matches in label
-        label_match = result["label"].str.contains(query, case=False, na=False)
-        result.loc[label_match, "relevance_score"] += 5
-
-        # Sort by relevance score
-        result = result.sort_values("relevance_score", ascending=False)
-
-    return result

--- a/pycancensus/vectors.py
+++ b/pycancensus/vectors.py
@@ -3,6 +3,7 @@ Functions for working with census vectors (variables).
 """
 
 import io
+import re
 import warnings
 from typing import Optional
 
@@ -231,10 +232,15 @@ def search_census_vectors(
         dataset=dataset, use_cache=use_cache, quiet=quiet, api_key=api_key
     )
 
-    # Search in both label and details columns (case-insensitive)
-    label_mask = vectors_df["label"].str.contains(search_term, case=False, na=False)
+    # Search in both label and details columns (case-insensitive, literal —
+    # regex metacharacters in queries like "income ($)" match literally)
+    label_mask = vectors_df["label"].str.contains(
+        search_term, case=False, na=False, regex=False
+    )
     details_mask = (
-        vectors_df["details"].str.contains(search_term, case=False, na=False)
+        vectors_df["details"].str.contains(
+            search_term, case=False, na=False, regex=False
+        )
         if "details" in vectors_df.columns
         else pd.Series([False] * len(vectors_df))
     )
@@ -256,30 +262,37 @@ def search_census_vectors(
 
 
 def find_census_vectors(
-    search_term: str,
+    query: str,
     dataset: str,
-    type_filter: Optional[str] = None,
+    type: str = "all",
+    query_type: str = "exact",
     interactive: bool = False,
     use_cache: bool = True,
     quiet: bool = False,
     api_key: Optional[str] = None,
 ) -> pd.DataFrame:
     """
-    Find census vectors with enhanced search capabilities.
+    Find census vectors using exact, semantic, or keyword search.
 
-    This is an alias for search_census_vectors with potential for future
-    enhancement with fuzzy matching and interactive selection.
+    Mirrors R cancensus's find_census_vectors(). Exact search matches the
+    query literally against vector details. Semantic search tolerates
+    spelling and phrasing differences via n-gram edit-distance matching.
+    Keyword search splits the query into words and ranks vectors by how
+    many of them match.
 
     Parameters
     ----------
-    search_term : str
-        Term to search for in vector labels or details.
+    query : str
+        Search query.
     dataset : str
         The dataset to search in (e.g., 'CA16').
-    type_filter : str, optional
-        Filter by vector type ('Total', 'Male', 'Female').
+    type : str, default "all"
+        Filter by vector type: 'all', 'total', 'male', or 'female'.
+    query_type : str, default "exact"
+        One of 'exact', 'semantic', or 'keyword'.
     interactive : bool, default False
-        If True, provides interactive selection (future enhancement).
+        For keyword search: prompt to show lower-precision matches beyond
+        the top-ranked results.
     use_cache : bool, default True
         If True, uses cached vector list if available.
     quiet : bool, default False
@@ -290,17 +303,216 @@ def find_census_vectors(
     Returns
     -------
     pd.DataFrame
-        Filtered DataFrame of vectors matching the search term.
-    """
-    if interactive:
-        # TODO: Implement interactive vector selection
-        print("Interactive mode not yet implemented. Using standard search.")
+        Matching vectors with columns vector, type, label, details.
 
-    return search_census_vectors(
-        search_term=search_term,
-        dataset=dataset,
-        type_filter=type_filter,
-        use_cache=use_cache,
-        quiet=quiet,
-        api_key=api_key,
+    Examples
+    --------
+    >>> import pycancensus as pc
+    >>> pc.find_census_vectors('Oji-cree', dataset='CA16', type='total')
+    >>> pc.find_census_vectors('after tax income', 'CA16', query_type='semantic')
+    >>> pc.find_census_vectors('commute duration', 'CA16', query_type='keyword')
+    """
+    type = type.lower()
+    query_type = query_type.lower()
+
+    if type not in ("total", "male", "female", "all"):
+        raise ValueError(
+            "Type must be one of 'all', 'total', 'female', or 'male'. "
+            "See help(find_census_vectors) for more details."
+        )
+    if query_type not in ("exact", "semantic", "keyword"):
+        raise ValueError(
+            "Query type must be one of 'exact', 'semantic', or 'keyword'. "
+            "See help(find_census_vectors) for more details."
+        )
+
+    vector_list = list_census_vectors(
+        dataset, use_cache=use_cache, quiet=True, api_key=api_key
+    )[["vector", "type", "label", "details"]].copy()
+    # Strip the common "... Census; 100% data;" prefix from details, like R
+    vector_list["details"] = vector_list["details"].str.replace(
+        r"^(.*)Census; |100% data; ", "", regex=True
     )
+
+    if type in ("total", "male", "female"):
+        vector_list = vector_list[vector_list["type"] == type.title()]
+
+    if query_type == "exact":
+        mask = vector_list["details"].str.contains(
+            query, case=False, na=False, regex=False
+        )
+        result = vector_list[mask]
+        if result.empty:
+            warnings.warn(
+                "No exact matches found. Please check spelling and try again "
+                "or consider using semantic or keyword search.\n"
+                "See help(find_census_vectors) for more details."
+            )
+        return result
+    elif query_type == "semantic":
+        return _semantic_search(query, vector_list, quiet=quiet)
+    else:  # keyword
+        return _keyword_search(query, vector_list, interactive=interactive)
+
+
+def _bounded_levenshtein(a: str, b: str, max_dist: int = 2) -> int:
+    """Levenshtein distance, returning max_dist + 1 once it exceeds max_dist."""
+    if abs(len(a) - len(b)) > max_dist:
+        return max_dist + 1
+    if a == b:
+        return 0
+    previous = list(range(len(b) + 1))
+    for i, ca in enumerate(a, start=1):
+        current = [i]
+        row_min = i
+        for j, cb in enumerate(b, start=1):
+            cost = min(
+                previous[j] + 1,  # deletion
+                current[j - 1] + 1,  # insertion
+                previous[j - 1] + (ca != cb),  # substitution
+            )
+            current.append(cost)
+            row_min = min(row_min, cost)
+        if row_min > max_dist:
+            return max_dist + 1
+        previous = current
+    return previous[-1]
+
+
+def _clean_text(text: str) -> str:
+    """Lowercase, replace punctuation with spaces, collapse whitespace."""
+    return re.sub(r"\s+", " ", re.sub(r"[^\w\s]", " ", text.lower())).strip()
+
+
+def _semantic_search(
+    query: str, vector_list: pd.DataFrame, quiet: bool = False
+) -> pd.DataFrame:
+    """N-gram edit-distance search, mirroring R cancensus semantic_search()."""
+    details = vector_list["details"].fillna("")
+    clean_details = [_clean_text(d) for d in details]
+
+    query_words = [w for w in re.split(r"[^a-z]+", query.lower()) if w]
+    word_count = max(len(query_words), 1)
+
+    # Build word-count-length n-grams (suffix n-grams at sentence ends)
+    ngram_counts: dict = {}
+    for sentence in clean_details:
+        words = sentence.split()
+        if not words:
+            continue
+        if word_count == 1:
+            grams = words
+        else:
+            grams = [" ".join(words[i : i + word_count]) for i in range(len(words))]
+        for gram in grams:
+            ngram_counts[gram] = ngram_counts.get(gram, 0) + 1
+    if not ngram_counts:
+        raise ValueError("No census vector details available to search against.")
+
+    # Most frequent n-grams first, matching R's table() ordering
+    ordered_ngrams = [g for g, _ in sorted(ngram_counts.items(), key=lambda kv: -kv[1])]
+
+    # Best match for the full query plus each individual query word
+    revised_query = [query.lower()] + query.lower().split()
+    best_ngrams = []
+    overall_min = None
+    for term in revised_query:
+        term_best_dist = None
+        term_best_gram = None
+        for gram in ordered_ngrams:
+            # Levenshtein is bounded below by the length difference; skip
+            # candidates that can never come within the match threshold
+            if abs(len(gram) - len(term)) > 2:
+                continue
+            dist = _bounded_levenshtein(term, gram, max_dist=2)
+            if term_best_dist is None or dist < term_best_dist:
+                term_best_dist = dist
+                term_best_gram = gram
+                if dist == 0:
+                    break
+        if term_best_dist is not None and term_best_dist <= 2:
+            if term_best_gram not in best_ngrams:
+                best_ngrams.append(term_best_gram)
+        if term_best_dist is not None:
+            overall_min = (
+                term_best_dist
+                if overall_min is None
+                else min(overall_min, term_best_dist)
+            )
+
+    if not best_ngrams:
+        warnings.warn(
+            "No close matches found. Please check spelling and try again or "
+            "consider using keyword search instead.\n"
+            "See help(find_census_vectors) for more details."
+        )
+        return vector_list.iloc[0:0]
+
+    pattern = "|".join(re.escape(g) for g in best_ngrams)
+    matched = [
+        bool(re.search(pattern, clean, re.IGNORECASE)) for clean in clean_details
+    ]
+    result = vector_list[matched]
+    if len(result) > 1 and not quiet:
+        print("Multiple possible matches. Results ordered by closeness.")
+    return result
+
+
+def _keyword_search(
+    query: str, vector_list: pd.DataFrame, interactive: bool = False
+) -> pd.DataFrame:
+    """Unigram match-count search, mirroring R cancensus keyword_search()."""
+    details = vector_list["details"].fillna("")
+    # Deduplicate words within each detail string so repeated words don't
+    # inflate the match count
+    clean_details = []
+    for d in details:
+        words = _clean_text(d).split()
+        seen: set = set()
+        unique_words = [w for w in words if not (w in seen or seen.add(w))]
+        clean_details.append(" ".join(unique_words))
+
+    # Drop empty tokens (e.g. from queries starting with a digit); an empty
+    # regex alternative would match every vector
+    query_tokens = [t for t in re.split(r"[^a-z]+", query.lower()) if t]
+    if not query_tokens:
+        warnings.warn(
+            "No matches found. Please check spelling and try again or "
+            "consider using semantic search instead.\n"
+            "See help(find_census_vectors) for more details."
+        )
+        return vector_list.iloc[0:0]
+
+    word_pattern = re.compile(
+        r"\b(?:" + "|".join(re.escape(t) for t in query_tokens) + r")\b",
+        re.IGNORECASE,
+    )
+    n_matches = pd.Series(
+        [len(word_pattern.findall(clean)) for clean in clean_details],
+        index=vector_list.index,
+    )
+
+    if (n_matches == 0).all():
+        warnings.warn(
+            "No matches found. Please check spelling and try again or "
+            "consider using semantic search instead.\n"
+            "See help(find_census_vectors) for more details."
+        )
+        return vector_list.iloc[0:0]
+
+    max_matches = n_matches.max()
+    top_res = vector_list[n_matches == max_matches]
+    other_res = vector_list[(n_matches > 0) & (n_matches < max_matches)]
+
+    if other_res.empty or not interactive:
+        return top_res
+
+    print(top_res)
+    answer = input(
+        f"\nThere are {len(other_res)} additional keyword matches with less "
+        "precision. Show more? [y/N] "
+    )
+    if answer.strip().lower().startswith("y"):
+        return other_res
+    print(f"Showing top {len(top_res)} results only")
+    return top_res

--- a/tests/integration/test_comprehensive_scenarios.py
+++ b/tests/integration/test_comprehensive_scenarios.py
@@ -205,7 +205,7 @@ class TestComprehensiveScenarios:
         print(f"   🔽 Found {len(children)} child vectors for {base_vector}")
 
         # Test vector search
-        housing_vectors = pc.find_census_vectors("CA21", "dwelling")
+        housing_vectors = pc.find_census_vectors("dwelling", "CA21", query_type="keyword")
         print(f"   🏠 Found {len(housing_vectors)} dwelling-related vectors")
 
         # Validate hierarchy functions work

--- a/tests/test_find_vectors.py
+++ b/tests/test_find_vectors.py
@@ -1,0 +1,108 @@
+"""Tests for find_census_vectors search modes."""
+
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from pycancensus.vectors import find_census_vectors, search_census_vectors
+
+
+def make_vector_list():
+    return pd.DataFrame(
+        {
+            "vector": [f"v_CA16_{i}" for i in range(1, 7)],
+            "type": ["Total", "Total", "Female", "Male", "Total", "Total"],
+            "label": [
+                "Income ($)",
+                "After-tax income",
+                "Commute duration",
+                "Commute duration",
+                "Ojibway",
+                "Oji-cree",
+            ],
+            "details": [
+                "Income ($); total income",
+                "Income; after-tax income of households",
+                "Commuting; commute duration for females",
+                "Commuting; commute duration for males",
+                "Aboriginal languages; Ojibway speakers",
+                "Aboriginal languages; Oji-cree speakers",
+            ],
+        }
+    )
+
+
+@pytest.fixture
+def mock_vectors():
+    with patch("pycancensus.vectors.list_census_vectors") as mock:
+        mock.return_value = make_vector_list()
+        yield mock
+
+
+class TestExactSearch:
+    def test_regex_metacharacters_match_literally(self, mock_vectors):
+        result = find_census_vectors("income ($)", "CA16")
+        assert result["vector"].tolist() == ["v_CA16_1"]
+
+    def test_case_insensitive(self, mock_vectors):
+        result = find_census_vectors("OJIBWAY", "CA16")
+        assert result["vector"].tolist() == ["v_CA16_5"]
+
+    def test_no_match_warns_and_returns_empty(self, mock_vectors):
+        with pytest.warns(UserWarning, match="No exact matches"):
+            result = find_census_vectors("xyzzy", "CA16")
+        assert result.empty
+
+    def test_type_filter(self, mock_vectors):
+        result = find_census_vectors("commute", "CA16", type="female")
+        assert result["vector"].tolist() == ["v_CA16_3"]
+
+
+class TestSemanticSearch:
+    def test_close_misspelling_matches(self, mock_vectors):
+        # One substitution away from "ojibway"
+        result = find_census_vectors(
+            "ojibwey", "CA16", query_type="semantic", quiet=True
+        )
+        assert "v_CA16_5" in result["vector"].tolist()
+
+    def test_distant_query_warns_and_returns_empty(self, mock_vectors):
+        with pytest.warns(UserWarning, match="No close matches"):
+            result = find_census_vectors(
+                "zzzzqqqqxxxx", "CA16", query_type="semantic", quiet=True
+            )
+        assert result.empty
+
+
+class TestKeywordSearch:
+    def test_ranked_by_match_count(self, mock_vectors):
+        result = find_census_vectors("commute duration", "CA16", query_type="keyword")
+        # Both commute vectors match both words; income rows match neither
+        assert set(result["vector"]) == {"v_CA16_3", "v_CA16_4"}
+
+    def test_digit_query_does_not_match_everything(self, mock_vectors):
+        with pytest.warns(UserWarning, match="No matches"):
+            result = find_census_vectors("12345", "CA16", query_type="keyword")
+        assert result.empty
+
+    def test_no_match_warns(self, mock_vectors):
+        with pytest.warns(UserWarning, match="No matches"):
+            result = find_census_vectors("xyzzy", "CA16", query_type="keyword")
+        assert result.empty
+
+
+class TestValidation:
+    def test_bad_type_raises(self, mock_vectors):
+        with pytest.raises(ValueError, match="Type must be one of"):
+            find_census_vectors("income", "CA16", type="banana")
+
+    def test_bad_query_type_raises(self, mock_vectors):
+        with pytest.raises(ValueError, match="Query type must be one of"):
+            find_census_vectors("income", "CA16", query_type="banana")
+
+
+class TestSearchCensusVectorsLiteral:
+    def test_regex_metacharacters_match_literally(self, mock_vectors):
+        result = search_census_vectors("income ($)", "CA16", quiet=True)
+        assert result["vector"].tolist() == ["v_CA16_1"]


### PR DESCRIPTION
UPDATE_PLAN.md items A4 + A7 + C2.

**The duplicate-definition bug:** `find_census_vectors()` was defined twice — an alias of `search_census_vectors` in vectors.py and a `search_type` variant in hierarchy.py, with the hierarchy one winning the package-level import (and taking `(dataset, query)` argument order, opposite to R). Both are replaced by one R-parity implementation in vectors.py with signature `find_census_vectors(query, dataset, type="all", query_type="exact", ...)`.

**Modes ported from R cancensus 0.6.1** (`vector_discovery.R`), including all its 0.6.1 fixes:
- **exact** — literal matching; `"income ($)"` works instead of erroring (regex-escape fix)
- **semantic** — n-gram generation with suffix n-grams, bounded Levenshtein with length-bound pruning, per-query-word best matching. Verified to reproduce R 0.6.1's algorithm exactly on live CA16 data (541/541 identical matches for "after tax income", same per-term best n-grams). Note: the locally installed R 0.5.7 returns different results because 0.6.1 *fixed* its full-phrase-only bug.
- **keyword** — unigram match-count ranking, empty-token filtering (digit-leading queries can't match everything), optional interactive show-more prompt

**Also fixed:** `search_census_vectors()` treated the query as a regex via `str.contains`; now literal.

Exact and keyword modes verified byte-identical against R on live data ("Oji-cree": 4 matches, "commute duration": 18 matches). 12 new unit tests cover all modes, type filtering, validation, and the metacharacter cases.

**Breaking change:** package-level `find_census_vectors` argument order changes from `(dataset, query)` to R's `(query, dataset)`, and `search_type="regex"` is gone (R has no regex mode; use pandas directly for that).

🤖 Generated with [Claude Code](https://claude.com/claude-code)