### PR TITLE
fix: Validate API responses before caching; refresh cache on use_cache=False

### DIFF
--- a/pycancensus/cache.py
+++ b/pycancensus/cache.py
@@ -3,6 +3,7 @@ Caching functionality for pycancensus.
 """
 
 import os
+import warnings
 import pickle
 import hashlib
 from pathlib import Path
@@ -94,7 +95,7 @@ def cache_data(cache_key: str, data: Any) -> None:
         with open(cache_file, "wb") as f:
             pickle.dump(data, f)
     except Exception as e:
-        print(f"Warning: Failed to cache data: {e}")
+        warnings.warn(f"Failed to cache data: {e}")
 
 
 def list_cache() -> pd.DataFrame:

--- a/pycancensus/core.py
+++ b/pycancensus/core.py
@@ -113,10 +113,10 @@ def get_census(
         )
 
     # Check cache first
+    cache_key = _generate_cache_key(
+        dataset, processed_regions, vectors, level, geo_format
+    )
     if use_cache:
-        cache_key = _generate_cache_key(
-            dataset, processed_regions, vectors, level, geo_format
-        )
         cached_data = get_cached_data(cache_key)
         if cached_data is not None:
             if not quiet:
@@ -201,9 +201,10 @@ def get_census(
                 # data.csv returns CSV
                 result = _process_csv_response(response.text, vectors, labels)
 
-        # Cache the result
-        if use_cache:
-            cache_data(cache_key, result)
+        # Cache the result. use_cache=False means "don't read stale data",
+        # not "don't cache": a forced refresh still updates the cache,
+        # matching the R package
+        cache_data(cache_key, result)
 
         # Finish progress indicator
         if progress:
@@ -505,6 +506,14 @@ def _process_csv_response(csv_text, vectors, labels):
 
     # Fix column names by removing trailing/leading spaces (critical fix for API compatibility)
     df.columns = df.columns.str.strip()
+
+    # A 200 response can still carry an error payload instead of census
+    # data; never let that be processed (and cached) as data
+    if "GeoUID" not in df.columns:
+        raise ValueError(
+            f"Invalid API response, expected census CSV data but got: "
+            f"{csv_text[:200]!r}"
+        )
 
     # Apply shared normalization
     return _normalize_census_dataframe(df, vectors, labels)

--- a/tests/test_cache_semantics.py
+++ b/tests/test_cache_semantics.py
@@ -1,0 +1,78 @@
+"""Tests for get_census cache semantics and response validation."""
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from pycancensus.core import get_census, _process_csv_response
+
+VALID_CSV = 'GeoUID,Type,"Region Name",Population\n' '5915022,CSD,"Vancouver",662248\n'
+
+
+def make_response(text):
+    response = MagicMock()
+    response.text = text
+    return response
+
+
+class TestErrorBodyNotCached:
+    @patch("pycancensus.core.cache_data")
+    @patch("pycancensus.core.get_cached_data", return_value=None)
+    @patch("pycancensus.core.get_session")
+    @patch("pycancensus.core.get_api_key", return_value="test_key")
+    def test_error_payload_raises_and_is_not_cached(
+        self, mock_key, mock_get_session, mock_read, mock_write
+    ):
+        session = MagicMock()
+        session.post.return_value = make_response('{"error": "no data found"}')
+        mock_get_session.return_value = session
+
+        with pytest.raises(RuntimeError, match="Invalid API response"):
+            get_census("CA21", {"CSD": "5915022"}, quiet=True)
+
+        mock_write.assert_not_called()
+
+    @patch("pycancensus.core.cache_data")
+    @patch("pycancensus.core.get_cached_data", return_value=None)
+    @patch("pycancensus.core.get_session")
+    @patch("pycancensus.core.get_api_key", return_value="test_key")
+    def test_valid_response_is_cached(
+        self, mock_key, mock_get_session, mock_read, mock_write
+    ):
+        session = MagicMock()
+        session.post.return_value = make_response(VALID_CSV)
+        mock_get_session.return_value = session
+
+        result = get_census("CA21", {"CSD": "5915022"}, quiet=True)
+
+        assert len(result) == 1
+        mock_write.assert_called_once()
+
+
+class TestUseCacheFalseRefreshesCache:
+    @patch("pycancensus.core.cache_data")
+    @patch("pycancensus.core.get_cached_data")
+    @patch("pycancensus.core.get_session")
+    @patch("pycancensus.core.get_api_key", return_value="test_key")
+    def test_refresh_skips_read_but_still_writes(
+        self, mock_key, mock_get_session, mock_read, mock_write
+    ):
+        session = MagicMock()
+        session.post.return_value = make_response(VALID_CSV)
+        mock_get_session.return_value = session
+
+        get_census("CA21", {"CSD": "5915022"}, quiet=True, use_cache=False)
+
+        mock_read.assert_not_called()  # stale data not read
+        mock_write.assert_called_once()  # but the cache is refreshed
+
+
+class TestCsvValidation:
+    def test_html_error_page_rejected(self):
+        with pytest.raises(ValueError, match="Invalid API response"):
+            _process_csv_response("<html>Server Error</html>", None, "detailed")
+
+    def test_valid_csv_accepted(self):
+        result = _process_csv_response(VALID_CSV, None, "detailed")
+        assert result["GeoUID"].tolist() == ["5915022"]


### PR DESCRIPTION
UPDATE_PLAN.md items A5 + A6, paralleling R cancensus 0.6.1's WDS error-caching fix.

- **Error bodies no longer cached as data**: a 200 response carrying an error payload (JSON error, HTML error page) was parsed and written to the cache, poisoning subsequent `use_cache=True` calls. `_process_csv_response()` now rejects bodies without a `GeoUID` column before anything is cached. (The GeoJSON path already validated `features`.)
- **`use_cache=False` now refreshes the cache**: it previously skipped both read *and* write, so a forced refresh never updated the cache — R semantics are "don't read stale data, but store the fresh download," which this now matches.
- `cache_data()` failures go through `warnings.warn` instead of bare `print` (quiet-respecting, filterable).

5 new unit tests cover error-payload rejection (not cached, raises), valid-response caching, and the read-skip/write-still semantics of `use_cache=False`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)