### PR TITLE
feat: Add visualize_vector_hierarchy() ASCII tree visualization

### DIFF
--- a/pycancensus/__init__.py
+++ b/pycancensus/__init__.py
@@ -31,6 +31,7 @@ from .settings import (
 from .geometry import get_census_geometry
 from .cache import list_cache, remove_from_cache, clear_cache
 from .hierarchy import parent_census_vectors, child_census_vectors
+from .vector_viz import visualize_vector_hierarchy
 from .intersect_geometry import get_intersecting_geometries
 
 __all__ = [
@@ -55,5 +56,6 @@ __all__ = [
     "parent_census_vectors",
     "child_census_vectors",
     "find_census_vectors",
+    "visualize_vector_hierarchy",
     "get_intersecting_geometries",
 ]

--- a/pycancensus/vector_viz.py
+++ b/pycancensus/vector_viz.py
@@ -1,0 +1,181 @@
+"""ASCII tree visualization of census vector hierarchies."""
+
+from typing import Optional, Union
+
+import pandas as pd
+
+from .hierarchy import (
+    _clean_vector_input,
+    _dataset_from_vectors,
+    child_census_vectors,
+)
+from .utils import validate_dataset
+
+
+def visualize_vector_hierarchy(
+    vector: Union[str, pd.DataFrame],
+    dataset: Optional[str] = None,
+    max_depth: Optional[int] = None,
+    show_type: bool = False,
+    quiet: bool = False,
+    use_cache: bool = True,
+    api_key: Optional[str] = None,
+) -> pd.DataFrame:
+    """
+    Visualize a census vector hierarchy as an ASCII tree.
+
+    Displays the hierarchical structure of census vectors, helping users
+    understand parent/child relationships when selecting variables.
+    Mirrors R cancensus's visualize_vector_hierarchy().
+
+    Parameters
+    ----------
+    vector : str or pd.DataFrame
+        A census vector code (e.g., "v_CA16_2510") or a filtered DataFrame
+        as returned by list_census_vectors().
+    dataset : str, optional
+        The dataset to query. Only required if it cannot be inferred from
+        the vector code.
+    max_depth : int, optional
+        Maximum depth of the tree to display. Default shows the entire
+        hierarchy. Nodes truncated by max_depth are marked with "..."
+        rather than "(leaf)".
+    show_type : bool, default False
+        Show the type (Total/Male/Female) next to each vector.
+    quiet : bool, default False
+        Suppress messages.
+    use_cache : bool, default True
+        Whether to use cached data if available.
+    api_key : str, optional
+        API key for CensusMapper API.
+
+    Returns
+    -------
+    pd.DataFrame
+        The vectors displayed in the tree. The tree itself is printed to
+        the console as a side effect.
+
+    Examples
+    --------
+    >>> import pycancensus as pc
+    >>> pc.visualize_vector_hierarchy("v_CA16_2510")
+    >>> pc.visualize_vector_hierarchy("v_CA16_2510", max_depth=2, show_type=True)
+    """
+    from .vectors import list_census_vectors
+
+    vector_ids = _clean_vector_input(vector)
+    if not vector_ids:
+        raise ValueError("Empty vector input provided.")
+
+    if dataset is None:
+        try:
+            dataset = _dataset_from_vectors(vector_ids)
+        except ValueError:
+            raise ValueError(
+                "Cannot determine dataset from vector code. "
+                "Please provide the 'dataset' parameter."
+            )
+    dataset = validate_dataset(dataset)
+
+    all_vectors = list_census_vectors(
+        dataset, use_cache=use_cache, quiet=True, api_key=api_key
+    )
+    root_info = all_vectors[all_vectors["vector"].isin(vector_ids)]
+    if root_info.empty:
+        raise ValueError(
+            f"Vector '{', '.join(vector_ids)}' not found in dataset '{dataset}'."
+        )
+
+    if len(root_info) > 1:
+        if not quiet:
+            print(
+                f"Multiple vectors provided. Using first vector: "
+                f"{root_info['vector'].iloc[0]}"
+            )
+        root_info = root_info.iloc[[0]]
+
+    root_vector = root_info["vector"].iloc[0]
+
+    children = child_census_vectors(
+        root_vector,
+        dataset=dataset,
+        use_cache=use_cache,
+        api_key=api_key,
+        max_level=max_depth,
+    )
+    tree_vectors = pd.concat([root_info, children], ignore_index=True)
+
+    if not quiet:
+        print(f"Vector hierarchy for {root_vector} ({dataset}):\n")
+
+    root_label = root_info["label"].iloc[0]
+    if show_type:
+        root_label = f"{root_label} [{root_info['type'].iloc[0]}]"
+    print(f"{root_vector}: {root_label}")
+
+    # Parent sets for leaf detection: consult the full vector list so that
+    # nodes truncated by max_depth are not falsely labeled as leaves
+    tree_parents = set(tree_vectors["parent_vector"].dropna())
+    dataset_parents = set(all_vectors["parent_vector"].dropna())
+
+    _print_children(
+        root_vector,
+        tree_vectors,
+        tree_parents,
+        dataset_parents,
+        prefix="",
+        show_type=show_type,
+        current_depth=1,
+        max_depth=max_depth,
+    )
+
+    return tree_vectors
+
+
+def _print_children(
+    parent_vector: str,
+    tree_vectors: pd.DataFrame,
+    tree_parents: set,
+    dataset_parents: set,
+    prefix: str,
+    show_type: bool,
+    current_depth: int,
+    max_depth: Optional[int],
+) -> None:
+    """Recursively print the children of a vector as tree branches."""
+    if max_depth is not None and current_depth > max_depth:
+        return
+
+    direct_children = tree_vectors[tree_vectors["parent_vector"] == parent_vector]
+    n_children = len(direct_children)
+    if n_children == 0:
+        return
+
+    for i, (_, child) in enumerate(direct_children.iterrows()):
+        is_last = i == n_children - 1
+        connector = "└── " if is_last else "├── "
+        child_prefix = "    " if is_last else "│   "
+
+        label = child["label"]
+        if show_type:
+            label = f"{label} [{child['type']}]"
+
+        if child["vector"] not in dataset_parents:
+            leaf_indicator = " (leaf)"
+        elif child["vector"] not in tree_parents:
+            leaf_indicator = " ..."
+        else:
+            leaf_indicator = ""
+
+        print(f"{prefix}{connector}{child['vector']}: {label}{leaf_indicator}")
+
+        _print_children(
+            child["vector"],
+            tree_vectors,
+            tree_parents,
+            dataset_parents,
+            prefix=prefix + child_prefix,
+            show_type=show_type,
+            current_depth=current_depth + 1,
+            max_depth=max_depth,
+        )

--- a/tests/test_vector_viz.py
+++ b/tests/test_vector_viz.py
@@ -1,0 +1,75 @@
+"""Tests for visualize_vector_hierarchy ASCII tree rendering."""
+
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from pycancensus.vector_viz import visualize_vector_hierarchy
+
+
+def make_vector_list():
+    """v_CA21_1 -> (v_CA21_2 -> v_CA21_4, v_CA21_3); v_CA21_4 -> v_CA21_5."""
+    return pd.DataFrame(
+        {
+            "vector": ["v_CA21_1", "v_CA21_2", "v_CA21_3", "v_CA21_4", "v_CA21_5"],
+            "parent_vector": [None, "v_CA21_1", "v_CA21_1", "v_CA21_2", "v_CA21_4"],
+            "label": ["Root", "Branch", "Leaf A", "Twig", "Leaf B"],
+            "type": ["Total"] * 5,
+        }
+    )
+
+
+@pytest.fixture
+def mock_vectors():
+    with patch("pycancensus.vectors.list_census_vectors") as mock:
+        mock.return_value = make_vector_list()
+        yield mock
+
+
+def test_full_tree_rendering(mock_vectors, capsys):
+    result = visualize_vector_hierarchy("v_CA21_1", quiet=True)
+
+    out = capsys.readouterr().out
+    assert "v_CA21_1: Root" in out
+    assert "├── v_CA21_2: Branch" in out
+    assert "└── v_CA21_3: Leaf A (leaf)" in out
+    assert "│   └── v_CA21_4: Twig" in out
+    assert "└── v_CA21_5: Leaf B (leaf)" in out
+    # Returns root + all descendants
+    assert len(result) == 5
+
+
+def test_max_depth_marks_truncated_nodes(mock_vectors, capsys):
+    result = visualize_vector_hierarchy("v_CA21_1", max_depth=1, quiet=True)
+
+    out = capsys.readouterr().out
+    # v_CA21_2 has children in the dataset but not in the truncated tree
+    assert "v_CA21_2: Branch ..." in out
+    assert "v_CA21_3: Leaf A (leaf)" in out
+    assert "Twig" not in out
+    assert len(result) == 3  # root + 2 direct children
+
+
+def test_show_type(mock_vectors, capsys):
+    visualize_vector_hierarchy("v_CA21_1", show_type=True, quiet=True)
+    out = capsys.readouterr().out
+    assert "v_CA21_1: Root [Total]" in out
+
+
+def test_unknown_vector_raises(mock_vectors):
+    with pytest.raises(ValueError, match="not found in dataset"):
+        visualize_vector_hierarchy("v_CA21_999", quiet=True)
+
+
+def test_dataframe_input(mock_vectors, capsys):
+    df = make_vector_list()
+    result = visualize_vector_hierarchy(df[df["vector"] == "v_CA21_2"], quiet=True)
+    out = capsys.readouterr().out
+    assert "v_CA21_2: Branch" in out
+    assert len(result) == 3  # v_CA21_2 + v_CA21_4 + v_CA21_5
+
+
+def test_underivable_dataset_raises():
+    with pytest.raises(ValueError, match="Cannot determine dataset"):
+        visualize_vector_hierarchy("notavector")


### PR DESCRIPTION
UPDATE_PLAN.md item C1 — parity with the function added in R cancensus 0.6.0 (`vector_viz.R`), including the 0.6.1 truncation fix: nodes cut off by `max_depth` are marked `...` (checked against the full dataset vector list) instead of being mislabeled `(leaf)`.

Example output (live CA16 data):
```
v_CA16_2510: Total - Low-income status in 2015 ...
├── v_CA16_2513: 0 to 17 years
│   └── v_CA16_2516: 0 to 5 years (leaf)
├── v_CA16_2519: 18 to 64 years (leaf)
└── v_CA16_2522: 65 years and over (leaf)
```

6 unit tests cover full-tree rendering, max_depth truncation markers, show_type, DataFrame input, and error paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)