### PR TITLE
feat: Add region-list helpers and explorer launchers; fix UID dtypes

### DIFF
--- a/pycancensus/__init__.py
+++ b/pycancensus/__init__.py
@@ -12,12 +12,19 @@ __author__ = "Dmitry Shkolnik"
 __email__ = "shkolnikd@gmail.com"
 
 from .core import get_census
-from .regions import list_census_regions, search_census_regions
+from .regions import (
+    list_census_regions,
+    search_census_regions,
+    as_census_region_list,
+    add_unique_names_to_region_list,
+    explore_census_regions,
+)
 from .vectors import (
     list_census_vectors,
     search_census_vectors,
     find_census_vectors,
     label_vectors,
+    explore_census_vectors,
 )
 from .datasets import list_census_datasets, dataset_attribution
 from .settings import (
@@ -57,5 +64,9 @@ __all__ = [
     "child_census_vectors",
     "find_census_vectors",
     "visualize_vector_hierarchy",
+    "as_census_region_list",
+    "add_unique_names_to_region_list",
+    "explore_census_regions",
+    "explore_census_vectors",
     "get_intersecting_geometries",
 ]

--- a/pycancensus/regions.py
+++ b/pycancensus/regions.py
@@ -85,8 +85,18 @@ def list_census_regions(
         # The endpoint returns gzip-compressed CSV data
         response = get_session().get(url)
 
-        # Parse CSV response
-        df = pd.read_csv(io.StringIO(response.text))
+        # Parse CSV response. Identifier columns must stay strings to match
+        # R cancensus — pandas would otherwise infer them as floats
+        # (e.g. CMA_UID 59933.0), silently breaking string comparisons
+        df = pd.read_csv(
+            io.StringIO(response.text),
+            dtype={
+                "geo_uid": str,
+                "CMA_UID": str,
+                "CD_UID": str,
+                "PR_UID": str,
+            },
+        )
 
         # Map column names to match expected output format
         # CSV columns: name, geo_uid, type, population, flag, CMA_UID, CD_UID, PR_UID
@@ -173,3 +183,98 @@ def search_census_regions(
         print(f"No regions found matching '{search_term}'")
 
     return filtered_df
+
+
+def as_census_region_list(tbl: pd.DataFrame) -> dict:
+    """
+    Convert a (suitably filtered) DataFrame from list_census_regions()
+    to a regions dict suitable for passing to get_census().
+
+    Parameters
+    ----------
+    tbl : pd.DataFrame
+        A data frame, suitably filtered, as returned by
+        list_census_regions().
+
+    Returns
+    -------
+    dict
+        Mapping of aggregation level to list of region identifiers,
+        e.g. {"CSD": ["5915022", "3520005"]}.
+
+    Examples
+    --------
+    >>> import pycancensus as pc
+    >>> regions = pc.list_census_regions("CA16")
+    >>> csds = regions[regions["level"] == "CSD"].head(20)
+    >>> data = pc.get_census("CA16", regions=pc.as_census_region_list(csds),
+    ...                      vectors=["v_CA16_408"], level="Regions")
+    """
+    if not {"level", "region"}.issubset(tbl.columns):
+        raise ValueError(
+            "as_census_region_list() can only handle data frames "
+            "returned by list_census_regions()."
+        )
+    return {
+        level: group["region"].astype(str).tolist()
+        for level, group in tbl.groupby("level", sort=False)
+    }
+
+
+def add_unique_names_to_region_list(region_list: pd.DataFrame) -> pd.DataFrame:
+    """
+    Add a de-duplicated "Name" column to a region list.
+
+    Municipality names are not always unique, especially at the CSD level.
+    Duplicated names get the municipal status appended in parentheses; if
+    that still does not make them unique, the region identifier is added
+    as well.
+
+    Parameters
+    ----------
+    region_list : pd.DataFrame
+        A subset of a region list as returned by list_census_regions().
+
+    Returns
+    -------
+    pd.DataFrame
+        The same regions with an extra column "Name" with de-duplicated
+        names.
+    """
+    required = {"name", "municipal_status", "region"}
+    if not required.issubset(region_list.columns):
+        raise ValueError(
+            "add_unique_names_to_region_list() requires the columns "
+            f"{sorted(required)} as returned by list_census_regions()."
+        )
+    result = region_list.copy()
+    counts = result.groupby("name")["name"].transform("size")
+    result["Name"] = result["name"].where(
+        counts == 1,
+        result["name"] + " (" + result["municipal_status"].astype(str) + ")",
+    )
+    counts = result.groupby("Name")["Name"].transform("size")
+    result["Name"] = result["Name"].where(
+        counts == 1,
+        result["Name"] + " (" + result["region"].astype(str) + ")",
+    )
+    return result
+
+
+def explore_census_regions(dataset: str = "CA16") -> None:
+    """
+    Open the interactive CensusMapper region explorer in a browser.
+
+    Parameters
+    ----------
+    dataset : str, default "CA16"
+        The dataset to explore regions for.
+    """
+    import webbrowser
+
+    dataset = validate_dataset(dataset)
+    print(
+        "Opening interactive census region explorer at censusmapper.ca/api "
+        "in the browser"
+    )
+    webbrowser.open(f"https://censusmapper.ca/api/{dataset}#api_region")

--- a/pycancensus/vectors.py
+++ b/pycancensus/vectors.py
@@ -516,3 +516,22 @@ def _keyword_search(
         return other_res
     print(f"Showing top {len(top_res)} results only")
     return top_res
+
+
+def explore_census_vectors(dataset: str = "CA16") -> None:
+    """
+    Open the interactive CensusMapper variable explorer in a browser.
+
+    Parameters
+    ----------
+    dataset : str, default "CA16"
+        The dataset to explore vectors for.
+    """
+    import webbrowser
+
+    dataset = validate_dataset(dataset)
+    print(
+        "Opening interactive census variable explorer at censusmapper.ca/api "
+        "in the browser"
+    )
+    webbrowser.open(f"https://censusmapper.ca/api/{dataset}#api_variable")

--- a/tests/test_region_helpers.py
+++ b/tests/test_region_helpers.py
@@ -1,0 +1,79 @@
+"""Tests for region-list helper functions."""
+
+import pandas as pd
+import pytest
+
+from pycancensus.regions import (
+    add_unique_names_to_region_list,
+    as_census_region_list,
+)
+
+
+def make_region_list():
+    return pd.DataFrame(
+        {
+            "region": ["5915022", "3520005", "5917034", "5915025", "5915804"],
+            "name": ["Vancouver", "Toronto", "Victoria", "Langley", "Langley"],
+            "level": ["CSD", "CSD", "CSD", "CSD", "CSD"],
+            "municipal_status": ["CY", "C", "CY", "CY", "DM"],
+            "pop": [662248, 2794356, 91867, 28963, 132603],
+        }
+    )
+
+
+class TestAsCensusRegionList:
+    def test_groups_by_level(self):
+        df = pd.DataFrame(
+            {
+                "region": ["59", "5915022", "3520005"],
+                "level": ["PR", "CSD", "CSD"],
+                "name": ["BC", "Vancouver", "Toronto"],
+            }
+        )
+        result = as_census_region_list(df)
+        assert result == {"PR": ["59"], "CSD": ["5915022", "3520005"]}
+
+    def test_regions_coerced_to_str(self):
+        df = pd.DataFrame({"region": [59, 35], "level": ["PR", "PR"]})
+        assert as_census_region_list(df) == {"PR": ["59", "35"]}
+
+    def test_missing_columns_raises(self):
+        with pytest.raises(ValueError, match="list_census_regions"):
+            as_census_region_list(pd.DataFrame({"GeoUID": ["59"]}))
+
+    def test_roundtrip_works_with_get_census_format(self):
+        regions = as_census_region_list(make_region_list())
+        assert set(regions) == {"CSD"}
+        assert len(regions["CSD"]) == 5
+
+
+class TestAddUniqueNames:
+    def test_unique_names_unchanged(self):
+        result = add_unique_names_to_region_list(make_region_list())
+        assert result.loc[result["region"] == "5915022", "Name"].iloc[0] == "Vancouver"
+
+    def test_duplicates_get_municipal_status(self):
+        result = add_unique_names_to_region_list(make_region_list())
+        langley_names = set(result.loc[result["name"] == "Langley", "Name"])
+        assert langley_names == {"Langley (CY)", "Langley (DM)"}
+
+    def test_still_duplicated_names_get_region_id(self):
+        df = make_region_list()
+        # Make both Langleys the same municipal status so status alone
+        # cannot disambiguate
+        df["municipal_status"] = "CY"
+        result = add_unique_names_to_region_list(df)
+        langley_names = set(result.loc[result["name"] == "Langley", "Name"])
+        assert langley_names == {
+            "Langley (CY) (5915025)",
+            "Langley (CY) (5915804)",
+        }
+
+    def test_original_columns_preserved(self):
+        result = add_unique_names_to_region_list(make_region_list())
+        for col in ["region", "name", "level", "municipal_status", "pop"]:
+            assert col in result.columns
+
+    def test_missing_columns_raises(self):
+        with pytest.raises(ValueError, match="list_census_regions"):
+            add_unique_names_to_region_list(pd.DataFrame({"name": ["a"]}))


### PR DESCRIPTION
UPDATE_PLAN.md item C4, plus a parity bug found while verifying.

**New functions (R parity):**
- `as_census_region_list()` — converts a filtered `list_census_regions()` DataFrame into the `regions` dict `get_census()` expects (`{"CSD": ["5915022", ...]}`).
- `add_unique_names_to_region_list()` — adds a de-duplicated `Name` column: duplicate names get municipal status appended, then the region ID if status alone doesn't disambiguate.
- `explore_census_regions()` / `explore_census_vectors()` — open CensusMapper's interactive explorer in the browser.

**Bug fix:** `list_census_regions()` let pandas infer UID columns as floats — `CMA_UID` came back as `59933.0` where R returns `"59933"`, so string filters like `r[r["CMA_UID"] == "59933"]` silently matched nothing. UID columns (`region`, `CMA_UID`, `CD_UID`, `PR_UID`) are now read as strings. (Stale caches keep old dtypes until refreshed; `use_cache=False` or `clear_cache()` picks up the fix.)

Verified against R cancensus live: the Vancouver CMA CSD example yields identical 38 rows with the same four disambiguated names (`Langley (CY)/(DM)`, `North Vancouver (CY)/(DM)`). 9 new unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)