### PR TITLE
feat: Detect and remove locally cached data recalled by StatCan

### DIFF
--- a/pycancensus/__init__.py
+++ b/pycancensus/__init__.py
@@ -37,6 +37,11 @@ from .settings import (
 )
 from .geometry import get_census_geometry
 from .cache import list_cache, remove_from_cache, clear_cache
+from .recalls import (
+    get_recalled_database,
+    list_recalled_cached_data,
+    remove_recalled_cached_data,
+)
 from .hierarchy import parent_census_vectors, child_census_vectors
 from .vector_viz import visualize_vector_hierarchy
 from .intersect_geometry import get_intersecting_geometries
@@ -60,6 +65,9 @@ __all__ = [
     "list_cache",
     "remove_from_cache",
     "clear_cache",
+    "get_recalled_database",
+    "list_recalled_cached_data",
+    "remove_recalled_cached_data",
     "parent_census_vectors",
     "child_census_vectors",
     "find_census_vectors",

--- a/pycancensus/cache.py
+++ b/pycancensus/cache.py
@@ -3,6 +3,7 @@ Caching functionality for pycancensus.
 """
 
 import os
+import json
 import warnings
 import pickle
 import hashlib
@@ -75,9 +76,9 @@ def get_cached_data(cache_key: str) -> Optional[Any]:
     return None
 
 
-def cache_data(cache_key: str, data: Any) -> None:
+def cache_data(cache_key: str, data: Any, metadata: Optional[dict] = None) -> None:
     """
-    Cache data to disk.
+    Cache data to disk, optionally with a metadata sidecar.
 
     Parameters
     ----------
@@ -85,6 +86,10 @@ def cache_data(cache_key: str, data: Any) -> None:
         Unique identifier for the data.
     data : Any
         Data to cache.
+    metadata : dict, optional
+        Request metadata (dataset, level, vectors, data version, ...) stored
+        alongside the data in a .meta.json sidecar. Used for recalled-data
+        detection.
     """
     cache_path = Path(get_cache_path())
     cache_path.mkdir(parents=True, exist_ok=True)
@@ -94,8 +99,24 @@ def cache_data(cache_key: str, data: Any) -> None:
     try:
         with open(cache_file, "wb") as f:
             pickle.dump(data, f)
+        if metadata is not None:
+            meta_file = cache_path / f"{cache_key}.meta.json"
+            with open(meta_file, "w") as f:
+                json.dump(metadata, f)
     except Exception as e:
         warnings.warn(f"Failed to cache data: {e}")
+
+
+def get_cache_metadata(cache_key: str) -> Optional[dict]:
+    """Read the metadata sidecar for a cached entry, if present."""
+    meta_file = Path(get_cache_path()) / f"{cache_key}.meta.json"
+    if meta_file.exists():
+        try:
+            with open(meta_file) as f:
+                return json.load(f)
+        except Exception:
+            return None
+    return None
 
 
 def list_cache() -> pd.DataFrame:
@@ -130,15 +151,18 @@ def list_cache() -> pd.DataFrame:
     for cache_file in cache_path.glob("*.pkl"):
         try:
             stat = cache_file.stat()
-            cache_files.append(
-                {
-                    "cache_key": cache_file.stem,
-                    "file_path": str(cache_file),
-                    "size_mb": round(stat.st_size / (1024 * 1024), 2),
-                    "created": pd.Timestamp.fromtimestamp(stat.st_ctime),
-                    "modified": pd.Timestamp.fromtimestamp(stat.st_mtime),
-                }
-            )
+            entry = {
+                "cache_key": cache_file.stem,
+                "file_path": str(cache_file),
+                "size_mb": round(stat.st_size / (1024 * 1024), 2),
+                "created": pd.Timestamp.fromtimestamp(stat.st_ctime),
+                "modified": pd.Timestamp.fromtimestamp(stat.st_mtime),
+            }
+            metadata = get_cache_metadata(cache_file.stem)
+            if metadata is not None:
+                for key in ("dataset", "level", "vectors", "version", "geo_version"):
+                    entry[key] = metadata.get(key)
+            cache_files.append(entry)
         except Exception:
             continue
 
@@ -183,10 +207,11 @@ def remove_from_cache(
     removed_count = 0
 
     if all_cache:
-        # Remove all .pkl files
+        # Remove all .pkl files (and their metadata sidecars)
         for cache_file in cache_path.glob("*.pkl"):
             try:
                 cache_file.unlink()
+                (cache_path / f"{cache_file.stem}.meta.json").unlink(missing_ok=True)
                 removed_count += 1
             except Exception as e:
                 print(f"Warning: Failed to remove {cache_file}: {e}")
@@ -200,6 +225,7 @@ def remove_from_cache(
             if cache_file.exists():
                 try:
                     cache_file.unlink()
+                    (cache_path / f"{cache_key}.meta.json").unlink(missing_ok=True)
                     removed_count += 1
                     print(f"Removed cache: {cache_key}")
                 except Exception as e:

--- a/pycancensus/core.py
+++ b/pycancensus/core.py
@@ -6,6 +6,7 @@ import hashlib
 import io
 import json
 import warnings
+from datetime import datetime
 from typing import Dict, List, Optional, Union
 
 import pandas as pd
@@ -121,6 +122,9 @@ def get_census(
         if cached_data is not None:
             if not quiet:
                 print(f"Reading data from cache...")
+            from .recalls import check_recalled_data_and_warn
+
+            check_recalled_data_and_warn(cache_key)
             # Process labels for cached data
             cached_data = _extract_vector_metadata(cached_data, vectors, labels)
             return cached_data
@@ -172,7 +176,7 @@ def get_census(
         if geo_format == "geopandas" and vectors:
             # The geo.geojson endpoint doesn't properly return vector data
             # Use dedicated function to fetch and merge geo + vector data
-            result = _fetch_census_with_geometry_and_vectors(
+            result, data_version, geo_version = _fetch_census_with_geometry_and_vectors(
                 base_url, request_data, resolution, vectors, labels
             )
         else:
@@ -192,6 +196,14 @@ def get_census(
 
             response = get_session().post(f"{base_url}{endpoint}", files=multipart_data)
 
+            # Track the server data version for recalled-data detection
+            data_version = None
+            geo_version = None
+            if geo_format == "geopandas":
+                geo_version = response.headers.get("data-version")
+            else:
+                data_version = response.headers.get("data-version")
+
             # Process the response data based on endpoint
             if geo_format == "geopandas":
                 # geo.geojson returns JSON
@@ -203,8 +215,20 @@ def get_census(
 
         # Cache the result. use_cache=False means "don't read stale data",
         # not "don't cache": a forced refresh still updates the cache,
-        # matching the R package
-        cache_data(cache_key, result)
+        # matching the R package. Metadata enables recalled-data detection.
+        cache_data(
+            cache_key,
+            result,
+            metadata={
+                "dataset": dataset,
+                "regions": regions_for_json,
+                "level": level,
+                "vectors": list(vectors) if vectors else [],
+                "created_at": datetime.now().isoformat(),
+                "version": data_version,
+                "geo_version": geo_version,
+            },
+        )
 
         # Finish progress indicator
         if progress:
@@ -245,7 +269,7 @@ def _fetch_census_with_geometry_and_vectors(
     resolution: str,
     vectors: List[str],
     labels: str,
-) -> gpd.GeoDataFrame:
+):
     """
     Fetch census data with both geometry and vector data.
 
@@ -268,8 +292,9 @@ def _fetch_census_with_geometry_and_vectors(
 
     Returns
     -------
-    gpd.GeoDataFrame
-        GeoDataFrame with geometry and vector data merged.
+    tuple of (gpd.GeoDataFrame, str or None, str or None)
+        GeoDataFrame with geometry and vector data merged, plus the
+        data-version and geometry-version headers reported by the server.
     """
     # 1. Fetch geometry data (without vectors)
     geo_request_data = request_data.copy()
@@ -282,16 +307,18 @@ def _fetch_census_with_geometry_and_vectors(
     geo_response = get_session().post(
         f"{base_url}geo.geojson", files=geo_multipart_data
     )
+    geo_version = geo_response.headers.get("data-version")
     geo_data = geo_response.json()
     geo_result = _process_geojson_response(geo_data, None, labels)
 
     # 2. Fetch vector data using CSV endpoint
     csv_multipart_data = {key: (None, value) for key, value in request_data.items()}
     csv_response = get_session().post(f"{base_url}data.csv", files=csv_multipart_data)
+    data_version = csv_response.headers.get("data-version")
     csv_result = _process_csv_response(csv_response.text, vectors, labels)
 
     # 3. Merge the results on geographic identifier
-    return _merge_geo_and_csv_results(geo_result, csv_result)
+    return _merge_geo_and_csv_results(geo_result, csv_result), data_version, geo_version
 
 
 def _merge_geo_and_csv_results(

--- a/pycancensus/recalls.py
+++ b/pycancensus/recalls.py
@@ -1,0 +1,184 @@
+"""Detection and removal of locally cached data recalled by Statistics Canada.
+
+Statistics Canada occasionally recalls published census data. CensusMapper
+tracks these recalls and exposes them at /api/v1/recall.csv. Cached
+get_census() results record the server's data-version header, which is
+matched against the recall database to flag stale local data.
+"""
+
+import io
+import warnings
+from typing import Optional
+
+import pandas as pd
+
+from .cache import list_cache, remove_from_cache, session_cache_get, session_cache_set
+from .settings import CENSUSMAPPER_API_URL
+from .resilience import get_session
+
+_RECALL_CACHE_KEY = "_recall_database"
+_warned_this_session = False
+
+
+def get_recalled_database(refresh: bool = False) -> Optional[pd.DataFrame]:
+    """
+    Fetch the database of recalled data from CensusMapper.
+
+    Parameters
+    ----------
+    refresh : bool, default False
+        Force a re-download instead of using the session-cached copy.
+
+    Returns
+    -------
+    pd.DataFrame or None
+        Rows describing recalled data with columns api_version, dataset,
+        level, vector — or None if the database cannot be downloaded.
+    """
+    if not refresh:
+        cached = session_cache_get(_RECALL_CACHE_KEY)
+        if cached is not None:
+            return cached
+
+    try:
+        response = get_session().get(f"{CENSUSMAPPER_API_URL}/recall.csv")
+        data = pd.read_csv(io.StringIO(response.text), dtype=str)
+    except Exception:
+        warnings.warn("Unable to download recall database at this point.")
+        return None
+
+    if "api_version" not in data.columns:
+        warnings.warn("Unable to download recall database at this point.")
+        return None
+
+    session_cache_set(_RECALL_CACHE_KEY, data)
+    return data
+
+
+def _version_number(version: Optional[str]) -> Optional[int]:
+    """Parse the numeric part of a data version like "d.12" or "g.3"."""
+    if not isinstance(version, str) or "." not in version:
+        return None
+    try:
+        return int(version.split(".", 1)[1])
+    except ValueError:
+        return None
+
+
+def _level_matches(recall_level, entry_level) -> bool:
+    """A recall applies to its level, all levels (NaN), or 'Regions' entries."""
+    if pd.isna(recall_level) or recall_level == "":
+        return True
+    return entry_level == recall_level or entry_level == "Regions"
+
+
+def list_recalled_cached_data(
+    cached_data: Optional[pd.DataFrame] = None,
+) -> Optional[pd.DataFrame]:
+    """
+    List locally cached data that has been recalled by Statistics Canada.
+
+    Only cache entries written by pycancensus versions that record request
+    metadata (dataset, vectors, data version) can be checked.
+
+    Parameters
+    ----------
+    cached_data : pd.DataFrame, optional
+        Cache listing to check, as returned by list_cache(). Defaults to
+        the full local cache.
+
+    Returns
+    -------
+    pd.DataFrame or None
+        Rows of list_cache() describing recalled entries, or None if the
+        recall database could not be downloaded.
+
+    Examples
+    --------
+    >>> import pycancensus as pc
+    >>> pc.list_recalled_cached_data()
+    """
+    recall_db = get_recalled_database()
+    if recall_db is None:
+        return None
+
+    if cached_data is None:
+        cached_data = list_cache()
+    if cached_data.empty or "dataset" not in cached_data.columns:
+        return cached_data.iloc[0:0]
+
+    recalled_keys = []
+    for _, entry in cached_data.iterrows():
+        if pd.isna(entry.get("dataset")):
+            continue  # no metadata recorded for this entry
+        entry_vectors = set(entry.get("vectors") or [])
+        data_version = _version_number(entry.get("version"))
+        geo_version = _version_number(entry.get("geo_version"))
+
+        for _, recall in recall_db.iterrows():
+            if recall["dataset"] != entry["dataset"]:
+                continue
+            if not _level_matches(recall.get("level"), entry.get("level")):
+                continue
+            recall_num = _version_number(recall["api_version"])
+            if recall_num is None:
+                continue
+            if recall["api_version"].startswith("d."):
+                # Data recall: exact vector ID match (a recall of v_CA21_1
+                # must not flag v_CA21_10) for data at or below the
+                # recalled version
+                if (
+                    data_version is not None
+                    and data_version <= recall_num
+                    and recall.get("vector") in entry_vectors
+                ):
+                    recalled_keys.append(entry["cache_key"])
+                    break
+            elif recall["api_version"].startswith("g."):
+                # Geometry recall: applies to any cached geometry at or
+                # below the recalled version
+                if geo_version is not None and geo_version <= recall_num:
+                    recalled_keys.append(entry["cache_key"])
+                    break
+
+    return cached_data[cached_data["cache_key"].isin(recalled_keys)]
+
+
+def remove_recalled_cached_data() -> None:
+    """
+    Remove locally cached data that has been recalled by Statistics Canada.
+
+    Examples
+    --------
+    >>> import pycancensus as pc
+    >>> pc.remove_recalled_cached_data()
+    """
+    recalled = list_recalled_cached_data()
+    if recalled is None:
+        return
+    if recalled.empty:
+        print("No recalled data in cached data.")
+        return
+    size = recalled["size_mb"].sum()
+    remove_from_cache(cache_keys=recalled["cache_key"].tolist())
+    print(f"Removed {len(recalled)} recalled datasets totalling {size:.2f} MB.")
+
+
+def check_recalled_data_and_warn(cache_key: str) -> None:
+    """Warn (once per session) if a cached entry being read was recalled."""
+    global _warned_this_session
+    if _warned_this_session:
+        return
+
+    cache_listing = list_cache()
+    entry = cache_listing[cache_listing["cache_key"] == cache_key]
+    if entry.empty:
+        return
+    recalled = list_recalled_cached_data(entry)
+    if recalled is not None and not recalled.empty:
+        _warned_this_session = True
+        warnings.warn(
+            "Currently loaded data has been recalled by Statistics Canada. "
+            "Use list_recalled_cached_data() to inspect recalled locally "
+            "cached data and remove_recalled_cached_data() to remove it."
+        )

--- a/tests/test_recalls.py
+++ b/tests/test_recalls.py
@@ -1,0 +1,210 @@
+"""Tests for recalled-data detection."""
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+import pycancensus.cache as cache_mod
+import pycancensus.recalls as recalls_mod
+from pycancensus.recalls import (
+    check_recalled_data_and_warn,
+    get_recalled_database,
+    list_recalled_cached_data,
+)
+
+RECALL_CSV = (
+    "api_version,dataset,level,vector\n"
+    "d.2,CA21,,v_CA21_1\n"
+    "d.2,CA21,,v_CA21_983\n"
+    "g.1,CA21,,\n"
+    "d.5,CA16,CSD,v_CA16_401\n"
+)
+
+
+def make_recall_db():
+    import io
+
+    return pd.read_csv(io.StringIO(RECALL_CSV), dtype=str)
+
+
+def make_cache_listing(rows):
+    base = {
+        "cache_key": "k",
+        "file_path": "/tmp/k.pkl",
+        "size_mb": 0.5,
+        "created": pd.Timestamp("2026-01-01"),
+        "modified": pd.Timestamp("2026-01-01"),
+        "dataset": None,
+        "level": None,
+        "vectors": None,
+        "version": None,
+        "geo_version": None,
+    }
+    return pd.DataFrame([{**base, **row} for row in rows])
+
+
+@pytest.fixture(autouse=True)
+def clean_state():
+    cache_mod._session_cache.clear()
+    recalls_mod._warned_this_session = False
+    yield
+    cache_mod._session_cache.clear()
+    recalls_mod._warned_this_session = False
+
+
+@pytest.fixture
+def mock_recall_db():
+    with patch.object(recalls_mod, "get_recalled_database") as mock:
+        mock.return_value = make_recall_db()
+        yield mock
+
+
+class TestGetRecalledDatabase:
+    @patch("pycancensus.recalls.get_session")
+    def test_downloads_and_session_caches(self, mock_get_session):
+        response = MagicMock()
+        response.text = RECALL_CSV
+        session = MagicMock()
+        session.get.return_value = response
+        mock_get_session.return_value = session
+
+        first = get_recalled_database()
+        second = get_recalled_database()
+
+        assert session.get.call_count == 1  # second call served from memory
+        assert list(first.columns) == ["api_version", "dataset", "level", "vector"]
+        pd.testing.assert_frame_equal(first, second)
+
+    @patch("pycancensus.recalls.get_session")
+    def test_download_failure_warns_and_returns_none(self, mock_get_session):
+        mock_get_session.return_value.get.side_effect = ConnectionError("down")
+        with pytest.warns(UserWarning, match="Unable to download"):
+            assert get_recalled_database() is None
+
+
+class TestListRecalledCachedData:
+    def test_exact_vector_match_flagged(self, mock_recall_db):
+        listing = make_cache_listing(
+            [
+                {
+                    "cache_key": "hit",
+                    "dataset": "CA21",
+                    "level": "CSD",
+                    "vectors": ["v_CA21_983"],
+                    "version": "d.1",
+                }
+            ]
+        )
+        result = list_recalled_cached_data(listing)
+        assert result["cache_key"].tolist() == ["hit"]
+
+    def test_recall_does_not_overmatch_vector_prefix(self, mock_recall_db):
+        # Recall of v_CA21_1 must NOT flag v_CA21_10 (R 0.6.1 fix)
+        listing = make_cache_listing(
+            [
+                {
+                    "cache_key": "prefix",
+                    "dataset": "CA21",
+                    "level": "CSD",
+                    "vectors": ["v_CA21_10"],
+                    "version": "d.1",
+                }
+            ]
+        )
+        assert list_recalled_cached_data(listing).empty
+
+    def test_newer_data_not_flagged(self, mock_recall_db):
+        # Data downloaded after the recall (version d.3 > recall d.2) is fixed
+        listing = make_cache_listing(
+            [
+                {
+                    "cache_key": "fresh",
+                    "dataset": "CA21",
+                    "level": "CSD",
+                    "vectors": ["v_CA21_983"],
+                    "version": "d.3",
+                }
+            ]
+        )
+        assert list_recalled_cached_data(listing).empty
+
+    def test_geometry_recall_flagged(self, mock_recall_db):
+        listing = make_cache_listing(
+            [
+                {
+                    "cache_key": "geo",
+                    "dataset": "CA21",
+                    "level": "CT",
+                    "vectors": [],
+                    "geo_version": "g.1",
+                }
+            ]
+        )
+        assert list_recalled_cached_data(listing)["cache_key"].tolist() == ["geo"]
+
+    def test_level_specific_recall(self, mock_recall_db):
+        listing = make_cache_listing(
+            [
+                {
+                    "cache_key": "right-level",
+                    "dataset": "CA16",
+                    "level": "CSD",
+                    "vectors": ["v_CA16_401"],
+                    "version": "d.4",
+                },
+                {
+                    "cache_key": "other-level",
+                    "dataset": "CA16",
+                    "level": "CT",
+                    "vectors": ["v_CA16_401"],
+                    "version": "d.4",
+                },
+            ]
+        )
+        result = list_recalled_cached_data(listing)
+        assert result["cache_key"].tolist() == ["right-level"]
+
+    def test_entries_without_metadata_skipped(self, mock_recall_db):
+        listing = make_cache_listing([{"cache_key": "legacy"}])
+        assert list_recalled_cached_data(listing).empty
+
+    def test_returns_none_when_db_unavailable(self):
+        with patch.object(recalls_mod, "get_recalled_database", return_value=None):
+            assert list_recalled_cached_data(make_cache_listing([])) is None
+
+
+class TestWarnOnCacheRead:
+    def test_warns_once_per_session(self, mock_recall_db):
+        listing = make_cache_listing(
+            [
+                {
+                    "cache_key": "hit",
+                    "dataset": "CA21",
+                    "level": "CSD",
+                    "vectors": ["v_CA21_983"],
+                    "version": "d.1",
+                }
+            ]
+        )
+        with patch.object(recalls_mod, "list_cache", return_value=listing):
+            with pytest.warns(UserWarning, match="has been recalled"):
+                check_recalled_data_and_warn("hit")
+            # Second read: no warning (once per session)
+            check_recalled_data_and_warn("hit")
+
+    def test_no_warning_for_clean_entry(self, mock_recall_db):
+        listing = make_cache_listing(
+            [
+                {
+                    "cache_key": "clean",
+                    "dataset": "CA21",
+                    "level": "CSD",
+                    "vectors": ["v_CA21_2"],
+                    "version": "d.9",
+                }
+            ]
+        )
+        with patch.object(recalls_mod, "list_cache", return_value=listing):
+            check_recalled_data_and_warn("clean")
+        assert recalls_mod._warned_this_session is False


### PR DESCRIPTION
UPDATE_PLAN.md item C3 — the last parity feature before the WDS scoping decision. pycancensus previously had zero recall handling (StatCan occasionally recalls published census data; CensusMapper tracks it at `/api/v1/recall.csv`).

**How it works** (mirrors R cancensus `recalled_data.R` + 0.6.1 fixes):
- `get_census()` cache writes now include a `.meta.json` sidecar recording dataset, level, vectors, and the server's `data-version` response header (verified live: current CA21 data reports `d.4`).
- `list_recalled_cached_data()` matches cached entries against the recall DB: data recalls (`d.N`) flag entries at or below the recalled version containing a recalled vector by **exact ID** (recall of `v_CA21_1` does not flag `v_CA21_10`); geometry recalls (`g.N`) flag cached geometry by version; level-specific recalls only flag matching levels.
- Version-aware: data re-downloaded after a recall (higher `data-version`) is **not** flagged.
- `remove_recalled_cached_data()` deletes flagged entries; `get_census()` warns once per session when reading recalled data from cache.
- Legacy cache entries (no metadata) are skipped.

11 unit tests cover exact-ID matching, the prefix-overmatch regression, version comparison, geometry recalls, level filtering, legacy entries, and the once-per-session warning. Live smoke test confirms metadata capture and a clean scan on fresh data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)