### PR TITLE
chore: Prepare 0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,34 +2,94 @@
 
 All notable changes to pycancensus will be documented in this file.
 
-## [Unreleased]
+## [0.2.0] - 2026-06-12
+
+This release synchronizes pycancensus with R cancensus 0.6.1, porting its
+bug fixes, performance work, and new features, and fixes several pycancensus
+bugs found during the comparison. Items reference the R cancensus equivalent
+where one exists.
+
+### Breaking Changes
+
+- `find_census_vectors()` now matches the R signature
+  `find_census_vectors(query, dataset, type="all", query_type="exact")`.
+  The previous package-level version took `(dataset, query, search_type=...)`.
+  The `"regex"` search type is gone (R has no regex mode); `"semantic"` is new.
+- `parent_census_vectors()` and `child_census_vectors()` now raise
+  `ValueError("Unable to determine dataset")` for vectors spanning multiple
+  datasets instead of silently inferring from the first vector (R parity).
 
 ### Bug Fixes
 
-#### National-Level Data Support
-- Added support for national-level census data retrieval (level='C')
-- Updated validation in `utils.py` to include 'C' in valid levels
-- Created comprehensive test suite in `tests/test_national_level.py`
-- Achieves feature parity with R cancensus for national baseline comparisons
+- **CRITICAL**: Fixed `list_census_vectors()` 404 error — the CensusMapper
+  API serves `/vector_info/<dataset>.csv` (dataset in the path). This also
+  broke `search_census_vectors()` and the hierarchy functions.
+- **CRITICAL**: `parent_census_vectors()` / `child_census_vectors()`
+  returned only direct parents/children; they now traverse the full
+  hierarchy via BFS, matching R's results exactly (verified against
+  R cancensus 0.6.1 on live data).
+- API retry logic now retries all 5xx plus 408/429 responses with
+  exponential backoff and honors numeric `Retry-After` headers (capped at
+  60s). 429 responses previously raised immediately without retrying.
+  [R 0.6.1]
+- Exact vector search matches queries containing regex metacharacters
+  (e.g. `"income ($)"`) literally instead of erroring; and
+  `search_census_vectors()` no longer interprets the query as a regex.
+  [R 0.6.1]
+- A 200 response carrying an error payload is no longer parsed and cached
+  as census data. [parallels R 0.6.1's WDS error-caching fix]
+- `use_cache=False` now refreshes the cache after re-downloading instead
+  of leaving stale data in place (R semantics).
+- `list_census_regions()` returned UID columns (`region`, `CMA_UID`,
+  `CD_UID`, `PR_UID`) as floats (`59933.0`); they are now strings,
+  matching R.
+- Cache-write failures warn via `warnings.warn` instead of printing.
+- Added support for national-level census data retrieval (level='C') for
+  national baseline comparisons, with validation and tests.
 
-#### API Endpoint Fixes
-- **CRITICAL**: Fixed `list_census_regions()` 404 error
-- Changed endpoint from `/api/v1/list_regions` to `/data_sets/{dataset}/place_names.csv`
-- Updated response parsing from JSON to CSV format
-- Now successfully retrieves all regions (5,518 for CA16/CA21)
+### New Features
 
-#### Test Infrastructure
-- Fixed CI test failures across Python 3.9 and 3.10
-- Made psutil dependency optional in performance tests
-- Updated mocked API tests to match new CSV response format
-- Improved cross-validation test assertions for better R compatibility checking
+- `find_census_vectors()` semantic search: n-gram edit-distance matching
+  tolerant of misspellings and phrasing, with per-word best matching and
+  length-bound pruning; and keyword search with match-count ranking.
+  [R 0.6.0/0.6.1]
+- `visualize_vector_hierarchy()`: ASCII tree visualization of vector
+  hierarchies with `max_depth` and `show_type`; nodes truncated by
+  `max_depth` are marked `...` rather than mislabeled as leaves.
+  [R 0.6.0/0.6.1]
+- Recalled-data handling: `get_census()` records the server's data version
+  with each cache entry and warns when reading recalled data;
+  `list_recalled_cached_data()` and `remove_recalled_cached_data()`
+  inspect and clean recalled entries. Vector matching is by exact ID.
+  [R 0.5.x/0.6.1]
+- `child_census_vectors()` gains `leaves_only`, `max_level`, and
+  `keep_parent`; both hierarchy functions accept DataFrame input.
+- Region-list helpers: `as_census_region_list()` converts a filtered
+  `list_census_regions()` result into the `regions` argument for
+  `get_census()`; `add_unique_names_to_region_list()` de-duplicates
+  region names by municipal status and region ID. [R parity]
+- `explore_census_vectors()` / `explore_census_regions()`: open the
+  CensusMapper interactive explorer in a browser. [R parity]
+- `list_cache()` reports per-entry metadata (dataset, level, vectors,
+  data version) for entries written by this version onward.
 
-### Documentation
+### Performance
 
-#### Professional Cleanup
-- Removed emojis from all public-facing documentation
-- Cleaned up README.md, tutorials, and examples for professional tone
-- Improved documentation clarity and readability
+- In-memory session cache for `list_census_vectors()` and
+  `list_census_regions()`: repeated calls within a session skip disk
+  entirely (~9x faster cache hits locally). [R 0.6.1]
+- Hierarchy traversal uses hash-based BFS instead of repeated DataFrame
+  filtering. [R 0.6.1]
+
+### Test Infrastructure & Documentation
+
+- Unit suite grew from 28 to 114 tests; new suites for retry behavior,
+  hierarchy traversal, search modes, session cache, cache semantics,
+  recalls, and region helpers.
+- Fixed `list_census_regions()` endpoint (`/data_sets/{dataset}/place_names.csv`)
+  and CI failures across Python versions; pinned black below 26 so new
+  stable-style releases don't break formatting checks.
+- Removed emojis from public-facing documentation and improved clarity.
 
 ## [0.1.0] - 2025-06-18
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,17 @@ Access, retrieve, and work with Canadian Census data and geography.
 ### Variable Discovery
 * `list_census_vectors()` - Browse all available variables
 * `search_census_vectors()` - Search variables by keyword
-* `parent_census_vectors()` - Navigate variable hierarchies upward
-* `child_census_vectors()` - Navigate variable hierarchies downward
-* `find_census_vectors()` - Enhanced variable search with fuzzy matching
+* `find_census_vectors()` - Exact, semantic (fuzzy), and keyword search
+* `parent_census_vectors()` - Full ancestry of a variable, like R cancensus
+* `child_census_vectors()` - Full descendant tree, with `leaves_only` and `max_level`
+* `visualize_vector_hierarchy()` - ASCII tree view of variable hierarchies
+* `explore_census_vectors()` - Open the interactive CensusMapper explorer
+
+### Region Discovery
+* `list_census_regions()` / `search_census_regions()` - Browse and search regions
+* `as_census_region_list()` - Convert filtered region lists into `get_census()` input
+* `add_unique_names_to_region_list()` - De-duplicate ambiguous municipality names
+* `explore_census_regions()` - Open the interactive CensusMapper explorer
 
 ### Geographic Capabilities
 * GeoPandas integration for spatial analysis
@@ -41,10 +49,11 @@ Access, retrieve, and work with Canadian Census data and geography.
 
 ### Reliability & Performance
 * Production-grade error handling with helpful messages
-* Automatic retry logic with exponential backoff
-* Connection pooling for improved performance
+* Automatic retry with exponential backoff, honoring server Retry-After headers
+* Connection pooling and in-memory session caching for metadata
 * Rate limiting to respect API constraints
-* Comprehensive caching system
+* Comprehensive file caching with StatCan data-recall detection
+  (`list_recalled_cached_data()` / `remove_recalled_cached_data()`)
 
 ## Installation
 

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -32,6 +32,9 @@ Region Operations
 
    list_census_regions
    search_census_regions
+   as_census_region_list
+   add_unique_names_to_region_list
+   explore_census_regions
 
 Vector/Variable Operations
 --------------------------
@@ -44,7 +47,9 @@ Vector/Variable Operations
    find_census_vectors
    parent_census_vectors
    child_census_vectors
+   visualize_vector_hierarchy
    label_vectors
+   explore_census_vectors
 
 Configuration Management
 ------------------------
@@ -68,3 +73,6 @@ Cache Management
    list_cache
    remove_from_cache
    clear_cache
+   get_recalled_database
+   list_recalled_cached_data
+   remove_recalled_cached_data

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -85,6 +85,27 @@ All Core Functions Available
    * - ``list_cancensus_cache()``
      - ``list_cache()``
      - ✅ 100%
+   * - ``visualize_vector_hierarchy()``
+     - ``visualize_vector_hierarchy()``
+     - ✅ 100%
+   * - ``as_census_region_list()``
+     - ``as_census_region_list()``
+     - ✅ 100%
+   * - ``add_unique_names_to_region_list()``
+     - ``add_unique_names_to_region_list()``
+     - ✅ 100%
+   * - ``explore_census_vectors()``
+     - ``explore_census_vectors()``
+     - ✅ 100%
+   * - ``explore_census_regions()``
+     - ``explore_census_regions()``
+     - ✅ 100%
+   * - ``list_recalled_cached_data()``
+     - ``list_recalled_cached_data()``
+     - ✅ 100%
+   * - ``remove_recalled_cached_data()``
+     - ``remove_recalled_cached_data()``
+     - ✅ 100%
 
 Syntax Conversion
 -----------------
@@ -455,12 +476,12 @@ Key Differences to Remember
 
    Python: ``None``
 
-5. **Function Parameter Order**
+5. **Function Signatures**
 
-   ``find_census_vectors()`` has different parameter order:
+   As of pycancensus 0.2.0, ``find_census_vectors()`` matches the R
+   signature exactly:
 
-   - R: ``find_census_vectors(query, dataset, ...)``
-   - Python: ``find_census_vectors(dataset, query, ...)``
+   - R and Python: ``find_census_vectors(query, dataset, type, query_type)``
 
 Performance Comparison
 ----------------------

--- a/pycancensus/__init__.py
+++ b/pycancensus/__init__.py
@@ -7,7 +7,7 @@ Census data and geography retrieved using the CensusMapper API.
 Documentation: https://pycancensus.readthedocs.io/
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 __author__ = "Dmitry Shkolnik"
 __email__ = "shkolnikd@gmail.com"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pycancensus"
-version = "0.1.0"
+version = "0.2.0"
 description = "Access, retrieve, and work with Canadian Census data and geography"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Release prep for 0.2.0 — the R cancensus 0.6.1 synchronization release (9 PRs: #10–#18).

- Version bump `0.1.0 → 0.2.0` (pyproject.toml + `__version__`)
- **CHANGELOG.md**: full 0.2.0 entry — breaking changes (`find_census_vectors` R-parity signature, mixed-dataset errors), critical fixes (vector_info 404, hierarchy traversal), features (semantic search, recall detection, visualizer, region helpers), and performance (session cache, BFS) — plus the previously unreleased national-level and regions-endpoint items
- **README**: feature lists updated with the new API surface
- **Migration guide**: new parity rows; removed the now-obsolete parameter-order difference note
- **API reference**: 8 new functions added to autosummary

Verified: 114 unit tests pass, black clean, `python -m build` produces a valid sdist+wheel as `pycancensus-0.2.0`.

After merge: publish a GitHub Release tagged `v0.2.0` — the existing `publish.yml` workflow uploads to PyPI on release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)