### PR TITLE
docs: Switch to furo theme; refresh tutorials for 0.2.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,8 +55,14 @@ templates_path = ['_templates']
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 # -- Options for HTML output ------------------------------------------------
-html_theme = 'sphinx_rtd_theme'
+html_theme = 'furo'
 html_static_path = ['_static']
+html_title = 'pycancensus'
+html_theme_options = {
+    'source_repository': 'https://github.com/dshkol/pycancensus/',
+    'source_branch': 'main',
+    'source_directory': 'docs/',
+}
 
 # -- Extension configuration -------------------------------------------------
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,7 +8,7 @@ geopandas>=0.8.0
 
 # Documentation dependencies
 sphinx>=4.0,<8.0
-sphinx-rtd-theme>=1.0
+furo
 myst-nb>=0.17,<1.3
 sphinx-gallery>=0.11,<0.20
 sphinx-autosummary-accessors

--- a/docs/tutorials/caching_data.md
+++ b/docs/tutorials/caching_data.md
@@ -202,13 +202,16 @@ except Exception as e:
 
 ## Controlling Cache Behavior
 
-### Bypassing Cache
+### Refreshing the Cache
 
-You can force fresh data by using the `use_cache=False` parameter:
+You can force fresh data by using the `use_cache=False` parameter. This
+skips reading any locally cached copy and re-downloads — and, matching the
+R cancensus behavior, the fresh result **replaces** the cached entry, so
+subsequent calls with `use_cache=True` see the updated data:
 
 ```{code-cell} python
 try:
-    # Force fresh data (bypass cache)
+    # Force a fresh download; the cache entry is refreshed afterwards
     print("Forcing fresh data download...")
 
     fresh_data = pc.get_census(
@@ -216,15 +219,23 @@ try:
         regions={"PR": "59"},  # British Columbia
         vectors=["v_CA21_1"],
         level="PR",
-        use_cache=False  # Force fresh download
+        use_cache=False  # Skip stale cache, re-download, refresh cache
     )
 
     print(f"Fresh data retrieved: {len(fresh_data)} records")
 
 except Exception as e:
-    print(f"Error bypassing cache: {e}")
+    print(f"Error refreshing cache: {e}")
     print("This requires API access")
 ```
+
+### In-Memory Session Cache
+
+Metadata lists (`list_census_vectors()`, `list_census_regions()`) are
+additionally held in an in-memory session cache: repeated calls within the
+same Python session skip the disk entirely, which makes hierarchy
+navigation and variable search snappy. The session cache is invalidated
+automatically by `remove_from_cache()` and `clear_cache()`.
 
 ### Cache Behavior
 
@@ -237,10 +248,44 @@ print("• Vector lists and region lists are cached")
 print("• Geographic boundaries are cached")
 print("• API responses include metadata for freshness")
 print("\nTo force refresh:")
-print("• Use use_cache=False parameter in get_census()")
+print("• Use use_cache=False in get_census() (re-downloads AND updates the cache)")
 print("• Remove specific cache entries with remove_from_cache()")
 print("• Clear entire cache with clear_cache()")
 ```
+
+## Recalled Data
+
+Statistics Canada occasionally *recalls* published census data after
+discovering errors. CensusMapper tracks these recalls, and pycancensus
+checks your local cache against them: each cached `get_census()` result
+records the server's data version, and reading recalled data from the
+cache produces a warning.
+
+You can inspect and clean recalled data explicitly:
+
+```{code-cell} python
+try:
+    # List locally cached entries that have been recalled by StatCan
+    recalled = pc.list_recalled_cached_data()
+    if recalled is None:
+        print("Recall database unavailable")
+    elif recalled.empty:
+        print("No recalled data in the local cache")
+    else:
+        print(f"{len(recalled)} recalled cache entries:")
+        print(recalled[["cache_key", "dataset", "level"]])
+
+    # Remove them (no-op if there are none)
+    pc.remove_recalled_cached_data()
+
+except Exception as e:
+    print(f"Error checking recalls: {e}")
+```
+
+Data downloaded *after* a recall reflects the corrected values and is not
+flagged. Cache entries written by pycancensus versions before 0.2.0 have
+no version metadata and are skipped by the recall check — clear them with
+`clear_cache()` if you want full coverage.
 
 ## Cache Maintenance
 
@@ -493,10 +538,12 @@ This tutorial covered comprehensive cache management for pycancensus:
 **Available Cache Functions:**
 - `get_cache_path()` - Get current cache directory
 - `set_cache_path(path)` - Set custom cache directory
-- `list_cache()` - List cached items
+- `list_cache()` - List cached items (with dataset/vector/version metadata)
 - `remove_from_cache(key)` - Remove specific cache entry
 - `clear_cache()` - Clear all cached data
-- `use_cache=False` - Bypass cache in get_census()
+- `list_recalled_cached_data()` - List cached data recalled by StatCan
+- `remove_recalled_cached_data()` - Remove recalled cached data
+- `use_cache=False` - Skip stale cache in get_census() and refresh it
 
 ### Best Practices Summary:
 1. **Let cache work automatically** - Default behavior is optimized

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -17,8 +17,9 @@ This tutorial demonstrates the enhanced pycancensus functionality with clear hie
 
 ## Key Features Demonstrated:
 - **list_census_vectors()** - Browse all available data variables
-- **Vector Hierarchies** - Navigate parent-child relationships
+- **Vector Hierarchies** - Navigate parent-child relationships, with ASCII tree visualization
 - **find_census_vectors()** - Exact, semantic, and keyword search
+- **Region Selection** - Filter region lists and de-duplicate ambiguous names
 - **Real Data Retrieval** - Get actual census data
 
 ```{note}
@@ -146,7 +147,67 @@ except Exception as e:
     print(f"Error searching vectors: {e}")
 ```
 
-## 4. Real Data Retrieval
+Semantic search tolerates misspellings and loose phrasing — useful when you
+don't know the exact census terminology:
+
+```{code-cell} python
+try:
+    # "comute" is misspelled on purpose; semantic search still finds it
+    commute_vectors = find_census_vectors('comute duration', 'CA16',
+                                          query_type='semantic', quiet=True)
+    print(f"Found {len(commute_vectors)} vectors despite the typo")
+    display(commute_vectors[['vector', 'label']].head(3))
+
+except Exception as e:
+    print(f"Error in semantic search: {e}")
+```
+
+You can also visualize where a vector sits in its hierarchy as an ASCII tree:
+
+```{code-cell} python
+from pycancensus import visualize_vector_hierarchy
+
+try:
+    # Low-income status hierarchy from the 2016 census
+    visualize_vector_hierarchy("v_CA16_2510", quiet=True)
+
+except Exception as e:
+    print(f"Error visualizing hierarchy: {e}")
+```
+
+## 4. Selecting Regions
+
+Region lists can be filtered like any DataFrame and passed straight to
+`get_census()` with `as_census_region_list()`. When municipality names are
+ambiguous (there are two Langleys in metro Vancouver),
+`add_unique_names_to_region_list()` de-duplicates them:
+
+```{code-cell} python
+from pycancensus import (
+    list_census_regions,
+    as_census_region_list,
+    add_unique_names_to_region_list,
+)
+
+try:
+    regions = list_census_regions("CA21", quiet=True)
+    metro_van = regions[(regions["level"] == "CSD") &
+                        (regions["CMA_UID"] == "59933")]
+
+    named = add_unique_names_to_region_list(metro_van)
+    print("De-duplicated names for duplicated municipalities:")
+    display(named.loc[named["name"].duplicated(keep=False),
+                      ["region", "name", "Name"]])
+
+    # Convert the selection into a get_census() regions argument
+    region_arg = as_census_region_list(metro_van.head(5))
+    print(f"\nRegions argument for get_census(): {region_arg}")
+
+except Exception as e:
+    print(f"Error selecting regions: {e}")
+```
+
+## 5. Real Data Retrieval
 
 Finally, let's get actual census data using our hierarchy vectors:
 
@@ -186,8 +247,9 @@ except Exception as e:
 1. **list_census_vectors()** - Browse 7,709+ available variables with explicit parent-child relationships
 2. **Hierarchy Navigation** - Navigate through income hierarchies from main categories to detailed brackets
 3. **parent_census_vectors()** & **child_census_vectors()** - Navigate up and down the hierarchy
-4. **find_census_vectors()** - Exact, semantic, and keyword search modes 
-5. **Real Data** - Actual census data retrieved and analyzed
+4. **find_census_vectors()** & **visualize_vector_hierarchy()** - Exact, semantic, and keyword search; ASCII hierarchy trees
+5. **as_census_region_list()** & **add_unique_names_to_region_list()** - Region selection helpers
+6. **Real Data** - Actual census data retrieved and analyzed
 
 **Key Improvement**: Unlike previous versions, these hierarchy functions now work with **clear, well-defined parent-child relationships** in the census data structure.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dev = [
 ]
 docs = [
     "sphinx>=4.0",
-    "sphinx-rtd-theme",
+    "furo",
     "myst-nb>=0.17",
     "sphinx-gallery>=0.11",
     "sphinx-autosummary-accessors",


### PR DESCRIPTION
Docs polish to go with the 0.2.0 release.

**Theme**: `sphinx_rtd_theme` → **furo** (modern, clean, dark-mode) across conf.py, the `docs` extras, and docs/requirements.txt, with repo source links configured.

**Tutorial fixes**:
- `caching_data.md` described `use_cache=False` as "bypass cache" — as of 0.2.0 it also *refreshes* the cache (R semantics); corrected throughout. Added sections on the in-memory session cache and StatCan **recalled-data detection** (`list_recalled_cached_data()` / `remove_recalled_cached_data()`).
- `getting_started.md` gains coverage of the new 0.2.0 discovery tools: typo-tolerant **semantic search** (`find_census_vectors('comute duration', ..., query_type='semantic')` → 552 hits), **`visualize_vector_hierarchy()`** ASCII trees, and a **region selection** section (`as_census_region_list()`, `add_unique_names_to_region_list()` with the two-Langleys example).

Verified with a full local `make html`: build succeeds on furo, and every new code cell executed against the live API with real output in the rendered HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)