### PR TITLE
docs: Add CITATION.cff; clarify license scope and StatCan attribution

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,23 @@
+cff-version: 1.2.0
+message: "If you use pycancensus in your research, please cite it as below."
+title: "pycancensus: access, retrieve, and work with Canadian Census data and geography in Python"
+type: software
+authors:
+  - family-names: Shkolnik
+    given-names: Dmitry
+    email: shkolnikd@gmail.com
+  - family-names: von Bergmann
+    given-names: Jens
+    email: jens@mountainmath.ca
+version: 0.2.0
+date-released: 2026-06-12
+license: MIT
+repository-code: "https://github.com/dshkol/pycancensus"
+url: "https://pycancensus.readthedocs.io/"
+keywords:
+  - census
+  - canada
+  - statistics-canada
+  - censusmapper
+  - gis
+  - demographics

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Dmitry Shkolnik, Jens von Bergmann
+Copyright (c) 2024-2026 Dmitry Shkolnik
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -225,9 +225,21 @@ Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for gui
 - Submitting pull requests
 - Reporting issues
 
+## Citing pycancensus
+
+If you use pycancensus in your research, please cite it (see
+[CITATION.cff](CITATION.cff), or use GitHub's "Cite this repository" button):
+
+> Shkolnik, D. and J. von Bergmann (2026). pycancensus: access, retrieve,
+> and work with Canadian Census data and geography in Python. v0.2.0.
+> https://github.com/dshkol/pycancensus
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+The license covers the pycancensus code; census **data** retrieved with it
+is subject to the Statistics Canada Open Licence — see the attribution
+requirements below.
 
 ## Related Packages
 
@@ -235,7 +247,9 @@ This package is explicitly a python port of the R [cancensus](https://github.com
 
 ## Statistics Canada Attribution
 
-Subject to the Statistics Canada Open Data License Agreement, licensed products using Statistics Canada data should employ the following acknowledgement of source:
+Subject to the Statistics Canada Open Data License Agreement, licensed products using Statistics Canada data should employ the following acknowledgement of source.
+pycancensus can generate the correct attribution text for the datasets you
+used: `pc.dataset_attribution(["CA16", "CA21"])`.
 
 **Acknowledgment of Source**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
     {name = "Dmitry Shkolnik", email = "shkolnikd@gmail.com"}
 ]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",


### PR DESCRIPTION
- **CITATION.cff**: Shkolnik & von Bergmann, v0.2.0 — GitHub will render the "Cite this repository" button with APA/BibTeX export, and Zenodo/scholarly indexers pick it up.
- **LICENSE**: copyright holder is Dmitry Shkolnik alone (2024–2026). Credit for the R cancensus lineage moves to the citation, which is the right instrument for it.
- **README**: new "Citing pycancensus" section with the text citation; License section now distinguishes code (MIT) from retrieved data (StatCan Open Licence); the StatCan attribution section points to `pc.dataset_attribution()` which generates the exact required text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)